### PR TITLE
Stack trace feature for explicit and implicit conditions improved

### DIFF
--- a/selene/conditions.py
+++ b/selene/conditions.py
@@ -3,19 +3,17 @@ from operator import contains, eq
 from selene.common.none_object import NoneObject
 from selene.exceptions import ConditionNotSatisfiedException
 
-
 or_not_to_be = lambda: True
 
 
 class Condition(object):
-
     def __init__(self):
         self.found = NoneObject('Condition#found')
 
     def __call__(self, entity):
         self.entity = entity
         self.found = self.entity()  # todo: do we actually need it?
-                                    # while we have self.found = wait_for(...
+        # while we have self.found = wait_for(...
         if self.apply():
             return self.found
         else:
@@ -26,16 +24,16 @@ class Condition(object):
     # todo: change this method to only stringify condition name and parameters,
     # todo:  and everything else should be provided in some describe method...
     def __str__(self):
-            expected_string = str(self.expected()) if (self.expected() is not None) else ""
-            actual_string = str(self.actual()) if (self.actual() is not None) else ""
-            return """
-            for %s found by: %s%s%s
-        """ % (self.identity(),
-               self.entity._locator._by,
-               """:
-            \texpected: """ + expected_string,
-               """
-            \t  actual: """ + actual_string)
+        expected_string = str(self.expected()) if (self.expected() is not None) else ""
+        actual_string = str(self.actual()) if (self.actual() is not None) else ""
+        return """
+            for {element} located by: {locator}
+            \texpected: {expected}
+            \t  actual: {actual}
+        """.format(element=self.identity(),
+                   locator=self.entity,
+                   expected=expected_string,
+                   actual=actual_string)
 
     def description(self):
         return "%s expecting: %s" % (self.__class__.__name__, self.expected())
@@ -67,7 +65,6 @@ class Condition(object):
 
 
 class CollectionCondition(Condition):
-
     def identity(self):
         return "elements"
 
@@ -116,6 +113,7 @@ class Enabled(Condition):
     def apply(self):
         return self.found.is_enabled()
 
+
 enabled = Enabled()
 
 
@@ -124,6 +122,7 @@ class Exist(Condition):
     """
     checks if element exist in DOM
     """
+
     def apply(self):
         return True
 
@@ -141,7 +140,6 @@ hidden = Hidden()
 
 
 class css_class(Condition):
-
     def __init__(self, class_attribute_value):
         # type: (str) -> None
         self.expected_containable_class = class_attribute_value
@@ -159,7 +157,6 @@ class css_class(Condition):
 
 
 class attribute(Condition):
-
     def __init__(self, name, value):
         # type: (str, str) -> None
         self.name = name
@@ -176,7 +173,9 @@ class attribute(Condition):
     def actual(self):
         return self.actual_value
 
+
 blank = attribute('value', '')
+
 
 #########################
 # COLLECTION CONDITIONS #
@@ -184,7 +183,6 @@ blank = attribute('value', '')
 
 
 class texts(CollectionCondition):
-
     def __init__(self, *expected_texts):
         self.expected_texts = expected_texts
         self.actual_texts = None
@@ -195,7 +193,7 @@ class texts(CollectionCondition):
     def apply(self):
         self.actual_texts = [item.text.encode('utf-8') for item in self.found]
         return len(self.actual_texts) == len(self.expected_texts) and \
-            all(map(self.compare_fn(), self.actual_texts, self.expected_texts))
+               all(map(self.compare_fn(), self.actual_texts, self.expected_texts))
 
     def expected(self):
         return self.expected_texts
@@ -205,12 +203,11 @@ class texts(CollectionCondition):
 
 
 class exact_texts(texts):
-
     def compare_fn(self):
         return eq
 
-class size(CollectionCondition):
 
+class size(CollectionCondition):
     def __init__(self, expected_size):
         self.expected_size = expected_size
         self.actual_size = None
@@ -230,7 +227,6 @@ empty = size(0)
 
 
 class size_at_least(CollectionCondition):
-
     def __init__(self, minimum_size):
         self.minimum_size = minimum_size
         self.actual_size = None

--- a/selene/conditions.py
+++ b/selene/conditions.py
@@ -31,7 +31,7 @@ class Condition(object):
             return """
             for %s found by: %s%s%s
         """ % (self.identity(),
-               self.entity,
+               self.entity._locator._by,
                """:
             \texpected: """ + expected_string,
                """

--- a/selene/conditions.py
+++ b/selene/conditions.py
@@ -32,10 +32,13 @@ class Condition(object):
             for {element} located by: {locator}
             \texpected: {expected}
             \t  actual: {actual}
+
+            reason: {reason}
         """.format(element=self.identity(),
                    locator=self.entity,
                    expected=expected_string,
-                   actual=actual_string)
+                   actual=actual_string,
+                   reason=self.reason())
 
     def description(self):
         return "%s expecting: %s" % (self.__class__.__name__, self.expected())
@@ -65,6 +68,8 @@ class Condition(object):
         except Exception:
             return False
 
+    def reason(self):
+        return "Condition Mismatch"
 
 class CollectionCondition(Condition):
 

--- a/selene/config.py
+++ b/selene/config.py
@@ -10,4 +10,4 @@ cash_elements = False
 """To cash all elements after first successful find
       config.cash_elements = True"""
 
-browser_name = Browser.FIREFOX
+browser_name = Browser.CHROME

--- a/selene/elements.py
+++ b/selene/elements.py
@@ -268,6 +268,7 @@ class SeleneElement(IWebElement):
     # *** Asserts (Explicit waits) ***
 
     def should(self, condition, timeout=None):
+        __tracebackhide__ = True
         if not timeout:
             timeout = config.timeout
         # todo: implement proper cashing
@@ -282,6 +283,7 @@ class SeleneElement(IWebElement):
     should_have = should
 
     def should_not(self, condition, timeout=None):
+        __tracebackhide__ = True
         if not timeout:
             timeout = config.timeout
         # todo: implement proper cashing
@@ -354,6 +356,7 @@ class SeleneElement(IWebElement):
             condition=be.visible)
 
     def click(self):
+        __tracebackhide__ = True
         self._execute(
             lambda: self.__delegate__.click(),
             condition=be.visible)
@@ -459,6 +462,7 @@ class SeleneElement(IWebElement):
     # *** private methods ***
 
     def _execute(self, command, condition=be.or_not_to_be):
+        __tracebackhide__ = True
         try:
             return command()
         except (WebDriverException,):

--- a/selene/elements.py
+++ b/selene/elements.py
@@ -34,7 +34,7 @@ class SearchContextWebElementLocator(ISeleneWebElementLocator):
 
     @property
     def description(self):
-        return "By.Selene: (%s).find(%s)" % (self._search_context, self._by)
+        return "Selene.find({})".format(self._by)
 
     def find(self):
         return self._search_context.find_element(*self._by)
@@ -48,7 +48,7 @@ class InnerWebElementLocator(ISeleneWebElementLocator):
 
     @property
     def description(self):
-        return "By.Selene: (%s).find(%s)" % (self._element, self._by)
+        return "%s.find(%s)" % (self._element, self._by)
 
     def find(self):
         # return self._element.should(be.in_dom).find_element(*self._by)

--- a/selene/tools.py
+++ b/selene/tools.py
@@ -1,10 +1,10 @@
+import sys
 from selenium.webdriver.remote.webdriver import WebDriver
 
 import selene.driver
 from selene import config
 from selene.elements import SeleneElement, SeleneCollection
 import selene.factory
-
 
 def quit_driver():
     get_driver().quit()

--- a/selene/wait.py
+++ b/selene/wait.py
@@ -13,7 +13,6 @@ def wait_for(entity, method, message='', timeout=None):
         timeout = config.timeout
     screen = None
     stacktrace = None
-    reason = None
     end_time = time.time() + timeout
     while True:
         try:
@@ -25,7 +24,6 @@ def wait_for(entity, method, message='', timeout=None):
             # where exceptions ara caught for the same purpose
             screen = getattr(exc, 'screen', None)
             stacktrace = getattr(exc, 'stacktrace', None)
-            reason = exc.msg if exc.msg else "Value Mismatch"
         time.sleep(config.poll_during_waits)
         if time.time() > end_time:
             break
@@ -33,11 +31,9 @@ def wait_for(entity, method, message='', timeout=None):
         """
             failed while waiting {timeout} seconds
             to assert {condition}{message}
-            reason: {reason}
         """.format(timeout=timeout,
                    condition=method.__class__.__name__,
-                   message=message,
-                   reason=reason),
+                   message=message),
         screen, stacktrace)
 
 

--- a/selene/wait.py
+++ b/selene/wait.py
@@ -13,7 +13,7 @@ def wait_for(entity, method, message='', timeout=None):
         timeout = config.timeout
     screen = None
     stacktrace = None
-
+    reason = None
     end_time = time.time() + timeout
     while True:
         try:
@@ -25,13 +25,20 @@ def wait_for(entity, method, message='', timeout=None):
             # where exceptions ara caught for the same purpose
             screen = getattr(exc, 'screen', None)
             stacktrace = getattr(exc, 'stacktrace', None)
+            reason = exc.msg if exc.msg else "Value Mismatch"
         time.sleep(config.poll_during_waits)
         if time.time() > end_time:
             break
     raise TimeoutException(
         """
-            failed while waiting %s seconds
-            to assert %s%s        """ % (timeout, method.__class__.__name__, message), screen, stacktrace)
+            failed while waiting {timeout} seconds
+            to assert {condition}{message}
+            reason: {reason}
+        """.format(timeout=timeout,
+                   condition=method.__class__.__name__,
+                   message=message,
+                   reason=reason),
+        screen, stacktrace)
 
 
 def wait_for_not(entity, method, message='', timeout=None):
@@ -62,6 +69,7 @@ def has(entity, method):
         return value if value is not None else False
     except (WebDriverException,) as exc:
         return False
+
 
 def has_not(entity, method):
     try:

--- a/selene/wait.py
+++ b/selene/wait.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 
 
 def wait_for(entity, method, message='', timeout=None):
+    __tracebackhide__ = True
     if not timeout:
         timeout = config.timeout
     screen = None
@@ -30,11 +31,11 @@ def wait_for(entity, method, message='', timeout=None):
     raise TimeoutException(
         """
             failed while waiting %s seconds
-            to assert %s%s
-        """ % (timeout, method.__class__.__name__, message), screen, stacktrace)
+            to assert %s%s        """ % (timeout, method.__class__.__name__, message), screen, stacktrace)
 
 
 def wait_for_not(entity, method, message='', timeout=None):
+    __tracebackhide__ = True
     if not timeout:
         timeout = config.timeout
     end_time = time.time() + timeout

--- a/tests/acceptance/condition_stack_trace.py
+++ b/tests/acceptance/condition_stack_trace.py
@@ -23,9 +23,11 @@ def test_should_be_suppressed_exception_message_for_explicit_condition():
     assert exception_message(ex) == ['Message: ',
                                      '            failed while waiting 4 seconds',
                                      '            to assert exact_text',
-                                     "            for element found by: ('css selector', '#selene_link'):",
+                                     "            for element located by: Selene.find(('css selector', '#selene_link'))",
                                      '            \texpected: Selene sit',
-                                     '            \t  actual: Selene site']
+                                     '            \t  actual: Selene site',
+                                     "",
+                                     "            reason: Condition Mismatch"]
 
 
 def test_should_be_suppressed_exception_message_for_implicit_condition():
@@ -36,6 +38,8 @@ def test_should_be_suppressed_exception_message_for_implicit_condition():
     assert exception_message(ex) == ['Message: ',
                                      '            failed while waiting 4 seconds',
                                      '            to assert Visible',
-                                     "            for element found by: ('css selector', '#hidden_button'):",
+                                     "            for element located by: Selene.find(('css selector', '#hidden_button'))",
                                      '            \texpected: ',
-                                     '            \t  actual:']
+                                     '            \t  actual: ',
+                                     "",
+                                     "            reason: Condition Mismatch"]

--- a/tests/acceptance/condition_stack_trace.py
+++ b/tests/acceptance/condition_stack_trace.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+import selene
+from selene.browsers import Browser
+from selene.conditions import exact_text
+from selene.tools import visit, s
+
+start_page = 'file://' + os.path.abspath(os.path.dirname(__file__)) + '/../resources/start_page.html'
+
+
+def exception_message(ex):
+    return str(ex.value).strip().splitlines()
+
+
+def test_should_be_suppressed_exception_message_for_explicit_condition():
+    with pytest.raises(TimeoutException) as ex:
+        selene.config.browser_name = Browser.CHROME
+        visit(start_page)
+        s("#selene_link").should_have(exact_text("Selene sit"))
+    assert exception_message(ex) == ['Message: ',
+                                     '            failed while waiting 4 seconds',
+                                     '            to assert exact_text',
+                                     "            for element found by: ('css selector', '#selene_link'):",
+                                     '            \texpected: Selene sit',
+                                     '            \t  actual: Selene site']
+
+
+def test_should_be_suppressed_exception_message_for_implicit_condition():
+    with pytest.raises(TimeoutException) as ex:
+        selene.config.browser_name = Browser.CHROME
+        visit(start_page)
+        s("#hidden_button").click()
+    assert exception_message(ex) == ['Message: ',
+                                     '            failed while waiting 4 seconds',
+                                     '            to assert Visible',
+                                     "            for element found by: ('css selector', '#hidden_button'):",
+                                     '            \texpected: ',
+                                     '            \t  actual:']

--- a/tests/acceptance/selene_page_factory.py
+++ b/tests/acceptance/selene_page_factory.py
@@ -2,7 +2,7 @@ import os
 
 import selene
 from selene.browsers import Browser
-from selene.conditions import exact_text
+from selene.conditions import exact_text, visible, hidden
 from selene.tools import visit, s
 
 start_page = 'file://' + os.path.abspath(os.path.dirname(__file__)) + '/../resources/start_page.html'

--- a/tests/acceptance/selene_page_factory.py
+++ b/tests/acceptance/selene_page_factory.py
@@ -2,7 +2,7 @@ import os
 
 import selene
 from selene.browsers import Browser
-from selene.conditions import exact_text
+from selene.conditions import exact_text, hidden, visible
 from selene.tools import visit, s
 
 start_page = 'file://' + os.path.abspath(os.path.dirname(__file__)) + '/../resources/start_page.html'

--- a/tests/resources/start_page.html
+++ b/tests/resources/start_page.html
@@ -11,5 +11,9 @@
 
 <button id="hidden_button" style="display: none">Press me</button>
 
+<div id="parent_div">
+    <a class="inner_link">Inner Link</a>
+</div>
+
 </body>
 </html>

--- a/tests/resources/start_page.html
+++ b/tests/resources/start_page.html
@@ -8,5 +8,8 @@
 <h1 id="header">Selene</h1>
 
 <a id="selene_link">Selene site</a>
+
+<button id="hidden_button" style="display: none">Press me</button>
+
 </body>
 </html>


### PR DESCRIPTION
This PR brings some improvement for stack trace printing after test fail.

Before, stacktrace was huge messy of code and exception message, now it will look like this:

```
 def test_should_be_suppressed_exception_message_for_implicit_condition():
            visit(start_page)
>           s("#hidden_button").click()
E           TimeoutException: Message: 
E                       failed while waiting 4 seconds
E                       to assert Visible
E                       for element found by: ('css selector', '#hidden_button'):
E                       	expected: 
E                       	  actual:
```

Elegant and understandable error messages. related to #24 