### PR TITLE
fix error msg tests for windows

### DIFF
--- a/tests/integration/error_messages_test.py
+++ b/tests/integration/error_messages_test.py
@@ -26,7 +26,7 @@ def teardown_module(m):
 
 
 def exception_message(ex):
-    return [line.strip() if not re.match('\s*screenshot: /.*?/\.selene/screenshots/\d+?/screen_\d+\.png\s*',line)
+    return [line.strip() if not re.match('\s*screenshot: .*?/\.selene/screenshots/\d+?/screen_\d+\.png\s*',line)
             else 'screenshot: //.selene/screenshots/*/screen_*.png'
             for line in str(ex.value.msg).strip().splitlines()]
 


### PR DESCRIPTION
Earlier tests in integration/error_messages_test.py were failing on my windows machine because of separator specific for unix file systems. I got rid of it. This should not affect tests at all. 
Also I suggest consider adding logic responsible for choosing right separator for corresponding platform. 