### PR TITLE
The browser.latest_screenshot was changed to public attribute

### DIFF
--- a/selene/browser.py
+++ b/selene/browser.py
@@ -66,7 +66,7 @@ def all(css_selector_or_by):
     return elements(css_selector_or_by)
 
 
-_latest_screenshot = NoneObject("selene.browser._latest_screenshot")
+latest_screenshot = NoneObject("selene.browser._latest_screenshot")
 
 
 def take_screenshot(path=None, filename=None):
@@ -81,10 +81,6 @@ def take_screenshot(path=None, filename=None):
     _latest_screenshot = screenshot_path
 
     return screenshot_path
-
-
-def latest_screenshot():
-    return _latest_screenshot
 
 
 # todo: consider adding aliases, like: wait_until, wait_brhwser_to

--- a/selene/elements.py
+++ b/selene/elements.py
@@ -11,6 +11,7 @@ from selenium.webdriver.common.keys import Keys
 
 from selene import config
 from selene import helpers
+from selene import browser
 from selene.abctypes.conditions import IEntityCondition
 from selene.abctypes.locators import ISeleneWebElementLocator, ISeleneListWebElementLocator
 from selene.abctypes.search_context import ISearchContext
@@ -23,6 +24,7 @@ from selene.support.conditions import be
 from selene.support.conditions import have
 from selene.wait import wait_for
 from selene.conditions import not_, is_matched
+
 
 try:
     from functools import lru_cache
@@ -188,6 +190,7 @@ def _wait_with_screenshot(webdriver, entity, condition, timeout=None, polling=No
         return wait_for(entity, condition, timeout, polling)
     except TimeoutException as e:
         screenshot = helpers.take_screenshot(webdriver, )
+        browser.latest_screenshot = screenshot
         msg = '''{original_msg}
             screenshot: file://{screenshot}'''.format(original_msg=e.msg, screenshot=screenshot)
         raise TimeoutException(msg, e.screen, e.stacktrace)

--- a/tests/integration/test_screenshots.py
+++ b/tests/integration/test_screenshots.py
@@ -107,5 +107,5 @@ def test_can_get_latest_screenshot_path():
     with pytest.raises(TimeoutException):
         s("#s").should_be(visible)
 
-    picture = latest_screenshot()
+    picture = latest_screenshot
     assert os.path.exists(picture)


### PR DESCRIPTION
The browser.latest_screenshot was changed to public attribute and elements._wait_for_screenshot stores the created screenshot in that attribute. Related test was also updated.

Goal: to have one public single source of the latest screenshot url for example in pytest-html reports.