### PR TITLE
Stripped text

### DIFF
--- a/selene/browser.py
+++ b/selene/browser.py
@@ -66,7 +66,7 @@ def all(css_selector_or_by):
     return elements(css_selector_or_by)
 
 
-_latest_screenshot = NoneObject("selene.browser._latest_screenshot")
+latest_screenshot = NoneObject("selene.browser._latest_screenshot")
 
 
 def take_screenshot(path=None, filename=None):
@@ -81,10 +81,6 @@ def take_screenshot(path=None, filename=None):
     _latest_screenshot = screenshot_path
 
     return screenshot_path
-
-
-def latest_screenshot():
-    return _latest_screenshot
 
 
 # todo: consider adding aliases, like: wait_until, wait_brhwser_to

--- a/selene/browser.py
+++ b/selene/browser.py
@@ -77,8 +77,8 @@ def take_screenshot(path=None, filename=None):
 
     screenshot_path = helpers.take_screenshot(driver(), path, filename)
 
-    global _latest_screenshot
-    _latest_screenshot = screenshot_path
+    global latest_screenshot
+    latest_screenshot = screenshot_path
 
     return screenshot_path
 

--- a/selene/conditions.py
+++ b/selene/conditions.py
@@ -250,6 +250,20 @@ class ExactText(ElementCondition):
 exact_text = ExactText
 
 
+class StrippedText(ElementCondition):
+    def __init__(self, expected_text):
+        self.expected_text = expected_text
+
+    def match(self, webelement):
+        actual_text = webelement.text
+        if not self.expected_text == str(actual_text).strip():
+            raise ConditionMismatchException(expected=self.expected_text, actual=actual_text)
+        return webelement
+
+
+stripped_text = StrippedText
+
+
 class CssClass(ElementCondition):
     def __init__(self, expected):
         self.expected = expected

--- a/selene/elements.py
+++ b/selene/elements.py
@@ -522,6 +522,11 @@ class SeleneElement(with_metaclass(DelegatingMeta, IWebElement)):
             lambda it: it.id,
             condition=be.in_dom)
 
+    # Additional properties
+
+    @property
+    def stripped_text(self):
+        return self.text.strip()
 
 class SeleneCollection(with_metaclass(DelegatingMeta, Sequence)):
     """

--- a/selene/elements.py
+++ b/selene/elements.py
@@ -11,6 +11,7 @@ from selenium.webdriver.common.keys import Keys
 
 from selene import config
 from selene import helpers
+from selene import browser
 from selene.abctypes.conditions import IEntityCondition
 from selene.abctypes.locators import ISeleneWebElementLocator, ISeleneListWebElementLocator
 from selene.abctypes.search_context import ISearchContext
@@ -23,6 +24,7 @@ from selene.support.conditions import be
 from selene.support.conditions import have
 from selene.wait import wait_for
 from selene.conditions import not_, is_matched
+
 
 try:
     from functools import lru_cache
@@ -188,6 +190,7 @@ def _wait_with_screenshot(webdriver, entity, condition, timeout=None, polling=No
         return wait_for(entity, condition, timeout, polling)
     except TimeoutException as e:
         screenshot = helpers.take_screenshot(webdriver, )
+        browser.latest_screenshot = screenshot
         msg = '''{original_msg}
             screenshot: file://{screenshot}'''.format(original_msg=e.msg, screenshot=screenshot)
         raise TimeoutException(msg, e.screen, e.stacktrace)

--- a/selene/support/conditions/have.py
+++ b/selene/support/conditions/have.py
@@ -19,6 +19,10 @@ def text(partial_value):
     return conditions.text(partial_value)
 
 
+def stripped_text(value):
+    return conditions.stripped_text(value)
+
+
 def attribute(name, value):
     return conditions.attribute(name, value)
 

--- a/tests/integration/test_screenshots.py
+++ b/tests/integration/test_screenshots.py
@@ -107,5 +107,5 @@ def test_can_get_latest_screenshot_path():
     with pytest.raises(TimeoutException):
         s("#s").should_be(visible)
 
-    picture = latest_screenshot()
+    picture = latest_screenshot
     assert os.path.exists(picture)


### PR DESCRIPTION
Stripped text element property and condition added.
Goal: in many cases the web pages are rendered with unnecessary leading/trailing spaces which are not disturbing on the UI but causes validation errors with exact text matches. The goal is to validate these pages smoothly if the partial text matches are not reasonably precise.