### PR TITLE
Stripped text condition added.

### DIFF
--- a/selene/conditions.py
+++ b/selene/conditions.py
@@ -250,6 +250,20 @@ class ExactText(ElementCondition):
 exact_text = ExactText
 
 
+class StrippedText(ElementCondition):
+    def __init__(self, expected_text):
+        self.expected_text = expected_text
+
+    def match(self, webelement):
+        actual_text = webelement.text
+        if not self.expected_text == str(actual_text).strip():
+            raise ConditionMismatchException(expected=self.expected_text, actual=actual_text)
+        return webelement
+
+
+stripped_text = StrippedText
+
+
 class CssClass(ElementCondition):
     def __init__(self, expected):
         self.expected = expected

--- a/selene/support/conditions/have.py
+++ b/selene/support/conditions/have.py
@@ -19,6 +19,10 @@ def text(partial_value):
     return conditions.text(partial_value)
 
 
+def stripped_text(value):
+    return conditions.stripped_text(value)
+
+
 def attribute(name, value):
     return conditions.attribute(name, value)
 


### PR DESCRIPTION
Goal: in many cases the web pages are rendered with unnecessary leading/trailing spaces which are not disturbing on the UI but causes validation errors with exact text matches. The goal is to validate these pages smoothly if the partial text matches are not reasonably precise.