### PR TITLE
#203 resurrected filtered_scollection_nowaiting_search_test

### DIFF
--- a/tests/integration/collection__filtered_by_condition__no_waiting_search_test.py
+++ b/tests/integration/collection__filtered_by_condition__no_waiting_search_test.py
@@ -19,40 +19,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from selene.api.past import config
-from selene.api.past import css_class
-from selene.common.none_object import NoneObject
-from selene.api.past import SeleneDriver
-from tests_from_past.past.acceptance import get_test_driver
-from tests_from_past.integration.helpers import GivenPage
-
-__author__ = 'yashaka'
-
-driver = NoneObject('driver')  # type: SeleneDriver
-GIVEN_PAGE = NoneObject('GivenPage')  # type: GivenPage
-WHEN = GIVEN_PAGE  # type: GivenPage
-original_timeout = config.timeout
+from selene import have
+from tests.integration.helpers.givenpage import GivenPage
 
 
-def setup_module(m):
-    global driver
-    driver = SeleneDriver.wrap(get_test_driver())
-    global GIVEN_PAGE
-    GIVEN_PAGE = GivenPage(driver)
-    global WHEN
-    WHEN = GIVEN_PAGE
+def test_waits_nothing(session_browser):
+    page = GivenPage(session_browser.driver)
+    page.opened_empty()
+    elements = session_browser.all('li').filtered_by(have.css_class('will-appear'))
 
-
-def teardown_module(m):
-    driver.quit()
-
-
-def test_waits_nothing():
-    GIVEN_PAGE.opened_empty()
-    elements = driver.all('li').filtered_by(css_class('will-appear'))
-
-    WHEN.load_body('''
+    page.load_body('''
                    <ul>Hello to:
                        <li>Anonymous</li>
                        <li class='will-appear'>Bob</li>
@@ -60,7 +36,7 @@ def test_waits_nothing():
                    </ul>''')
     assert len(elements) == 2
 
-    WHEN.load_body_with_timeout('''
+    page.load_body_with_timeout('''
                                 <ul>Hello to:
                                     <li>Anonymous</li>
                                     <li class='will-appear'>Bob</li>


### PR DESCRIPTION
### What
Migrated autotest on selene 2 version, renamed by new convention:
```
was: filtered_scollection_nowaiting_search_test
now: collection__filtered_by_condition__with_timeout_search_test
```
Left old name of test function `test_waits_nothing`.

### Tests
Migrated test has passed
![image](https://user-images.githubusercontent.com/17043964/103317168-c004d480-4a3b-11eb-9d2e-495f7d66746e.png)

### Review
What to review ok/not ok:
- [x] new name of test module
- [x] name of test function