### PR TITLE
run code coverage step even if not all tests passed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           name: selene-codecov # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true
+        if: ${{ always() }}
 
       # can be organized better
       - name: Upload pytest test results


### PR DESCRIPTION
### Problem
"Code coverage" step on GitHubActions skips if even one test from previous step "Test selene with pytest" has been failed. In this case we loose a part of code coverage dynamic.
### Solution 
Run code coverage step even if not all tests passed in case to get the whole code coverage dynamic history.
