### PR TITLE
#234 clear warnings in current tests

### DIFF
--- a/tests/adhoc/straightforward_style_test.py
+++ b/tests/adhoc/straightforward_style_test.py
@@ -61,10 +61,10 @@ def test_selene_demo():
     tasks[2].should(be.not_.visible)
 
     tasks.collected(lambda task: task.all('label')).should(have.texts('1', '2'))
-    tasks.all('label').should(have.texts('1', '2'))
+    # tasks.all('label').should(have.texts('1', '2'))
 
     tasks.collected(lambda task: task.element('label')).should(have.texts('1', '2'))
-    tasks.all_first('label').should(have.texts('1', '2'))
+    # tasks.all_first('label').should(have.texts('1', '2'))
 
     s(by.id('toggle-all')).with_(timeout=config.timeout / 2).click()
     # browser.actions.click(s('//*[@id="clear-completed"]')()).perform()

--- a/tests/adhoc/straightforward_style_test.py
+++ b/tests/adhoc/straightforward_style_test.py
@@ -35,7 +35,7 @@ def test_selene_demo():
     # browser.driver.get('http://google.com')  # just in case, you can use the driver directly too
     # browser.driver().get('https://todomvc4tasj.herokuapp.com/')  # temporary this works too;)
     is_todo_mvc_loaded = 'return (Object.keys(require.s.contexts._.defined).length === 39)'
-    browser.with_(timeout=config.timeout*4).should(have.js_returned_true(is_todo_mvc_loaded))  # todo: make it work
+    browser.with_(timeout=config.timeout*4).should(have.js_returned(True, is_todo_mvc_loaded))  # todo: make it work
 
     for text in ['1', '2', '3']:
         s('#new-todo')\
@@ -69,4 +69,4 @@ def test_selene_demo():
     s(by.id('toggle-all')).with_(timeout=config.timeout / 2).click()
     # browser.actions.click(s('//*[@id="clear-completed"]')()).perform()
     s('//*[@id="clear-completed"]').click()
-    tasks.should(be.empty)
+    tasks.should(have.size(0))


### PR DESCRIPTION
### What 
Almost all warnings are cleared in current `selene/tests`
```shell
=============================== warnings summary ===============================
tests/adhoc/straightforward_style_test.py::test_selene_demo
  /Users/akotlyar/GitHubProjects/selene/selene/support/conditions/have.py:167: PendingDeprecationWarning: might be deprecated; use have.js_returned(True, ...) instead
    warnings.warn('might be deprecated; use have.js_returned(True, ...) instead', PendingDeprecationWarning)

tests/adhoc/straightforward_style_test.py::test_selene_demo
  /Users/akotlyar/GitHubProjects/selene/selene/core/entity.py:954: FutureWarning: might be renamed or deprecated in future; all is actually a shortcut for collected(lambda element: element.all(selector)...but we also have all_first and...it is yet unclear what name would be best for all_first as addition to all... all_first might confuse with all(...).first... I mean: all_first(selector) is actually collected(lambda e: e.element(selector)) but it is not the same as all(selector).first that is collected(lambda e: e.all(selector)).first ... o_O 
    'that is collected(lambda e: e.all(selector)).first ... o_O ', FutureWarning)

tests/adhoc/straightforward_style_test.py::test_selene_demo
  /Users/akotlyar/GitHubProjects/selene/selene/core/entity.py:974: FutureWarning: might be renamed or deprecated in future; it is yet unclear what name would be best... all_first might confuse with all(...).first... I mean: all_first(selector) is actually collected(lambda e: e.element(selector)) but it is not the same as all(selector).first that is collected(lambda e: e.all(selector)).first ... o_O 
    'that is collected(lambda e: e.all(selector)).first ... o_O ', FutureWarning)

tests/adhoc/straightforward_style_test.py::test_selene_demo
  /Users/akotlyar/GitHubProjects/selene/selene/core/match.py:238: DeprecationWarning: match.collection_is_empty or be.empty is deprecated; use more explicit and obvious have.size(0) instead
    'use more explicit and obvious have.size(0) instead', DeprecationWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 1 passed, 4 warnings in 5.37s =========================
```
### ToDo
clear last four warnings
- [x] 1. `have.js_returned_true()` 
- [x] 2. `match.collection_is_empty` or `be.empty`
- [x] 3. `ElementCollection.all()`
- [x] 4. `ElementCollection.all_first()`

Resolves #234 