### PR TITLE
add tests for shared browser hold_browser_open config

### DIFF
--- a/tests/acceptance/shared_browser/hold_open_test.py
+++ b/tests/acceptance/shared_browser/hold_open_test.py
@@ -1,0 +1,22 @@
+from selene import have
+from selene.support.shared import config, browser, SharedConfig
+
+
+def setup_module():
+    config.hold_browser_open = True
+
+
+def teardown_module():
+    config.hold_browser_open = SharedConfig().hold_browser_open
+
+
+def test_open_browser_with_hold():
+    browser.open('http://todomvc.com/examples/emberjs/')
+
+    browser.element('#new-todo').type('a').press_enter()
+
+
+def test_browser_still_opened():
+    browser.element('#new-todo').type('b').press_enter()
+
+    browser.all('#todo-list>li').should(have.texts('a', 'b'))

--- a/tests/acceptance/shared_browser/hold_open_test.py
+++ b/tests/acceptance/shared_browser/hold_open_test.py
@@ -8,6 +8,7 @@ def setup_module():
 
 def teardown_module():
     config.hold_browser_open = SharedConfig().hold_browser_open
+    browser.quit()
 
 
 def test_open_browser_with_hold():


### PR DESCRIPTION
Increased code coverage of property [`hold_browser_open`](
https://codecov.io/gh/yashaka/selene/compare/0e7ed43957d08ff37f37c731e8fc9136500b85c4...c9e38e874581b6aca022662ed1763ae74f579041/src/selene/support/shared/config.py)
![image](https://user-images.githubusercontent.com/17043964/104129136-6fb33e00-537c-11eb-9631-ac20980d6dec.png)
