### PR TITLE
add scripts with Package aliases and update Release process in README

### DIFF
--- a/.run/build.sh
+++ b/.run/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+poetry build

--- a/.run/bump_build_publish.sh
+++ b/.run/bump_build_publish.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 bash .run/bump_version.sh $1
-poetry publish --build
+bash .run/build.sh
+bash .rub/publish.sh

--- a/.run/bump_version.sh
+++ b/.run/bump_version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+version=$1
+if [[ $1 == '' ]]; then
+  echo -n 'please specify selene version: '
+  read text
+  version=$text
+fi
+poetry version $version
+new_vers=$(cat pyproject.toml | grep "^version = \"*\"" | cut -d'"' -f2)
+sed -i "" "s/__version__ = .*/__version__ = \'${new_vers}\'/g" selene/__init__.py

--- a/.run/bump_version_and_publish.sh
+++ b/.run/bump_version_and_publish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+bash .run/bump_version.sh $1
+poetry publish --build

--- a/.run/publish.sh
+++ b/.run/publish.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+poetry publish

--- a/README.md
+++ b/README.md
@@ -435,9 +435,9 @@ TBD
 
 or
 
-`bash .run/bump_version_and_publish.sh x.x.x`
+`bash .run/bump_build_publish.sh x.x.x`
 
-or 
+or if you want to control all by yourself
 
 1. manually bump version in `pyproject.toml` and `selene/__init.py:__version__`
 2. poetry publish --build

--- a/README.md
+++ b/README.md
@@ -429,5 +429,15 @@ TBD
 
 ## Release process
 
-1. python setup.py bdist_wheel
-2. twine upload dist/*
+1. bump version via `bash .run/bump_version.sh x.x.x`
+2. build via `bash .run/build.sh`
+3. publish via `bash .run/publish.sh`
+
+or
+
+`bash .run/bump_version_and_publish.sh x.x.x`
+
+or 
+
+1. manually bump version in `pyproject.toml` and `selene/__init.py:__version__`
+2. poetry publish --build


### PR DESCRIPTION
# What?
### Added bash script aliases for new release process
  1. `bump_version.sh` - automatically updates both `selene/__init__.py:__version` and `pyproject.toml:version`
  1. `build.sh` - building project with poetry
  1. `publish.sh` - publishing project with poetry.
  1. `bump_version_and_publish.sh` - do everything above.

###  Updated Release process in README:

> 
> 1. bump version via `bash .run/bump_version.sh x.x.x`
> 2. build via `bash .run/build.sh`
> 3. publish via `bash .run/publish.sh`
> 
> or
> 
> `bash .run/bump_version_and_publish.sh x.x.x`
> 
> or 
> 
> 1. manually bump version in `pyproject.toml` and `selene/__init.py:__version__`
> 2. `poetry publish --build`

# Why?
1. To make release more easier and automated.
1. Since moved `setup.py` to `pyproject.toml` - old release process instruction has became out of date and we need new release process instruction.

