### PR TITLE
up codecov-action 1.1.1->1.4.1; remove flags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,9 @@ jobs:
 
       # can be improved by flags/options
       - name: Code Coverage
-        uses: codecov/codecov-action@v1.1.1
+        uses: codecov/codecov-action@v1.4.1
         with:
           file: ./coverage.xml # optional
-          flags: unittests # optional
           name: selene-codecov # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true


### PR DESCRIPTION
## What?
Update codecov-action.
## Why?
Codecov seems a bit broken last time. It misses base reports
<details>
<img width="1304" alt=2021-04-28 9 28 22" src="https://user-images.githubusercontent.com/17043964/116356577-217b5b00-a804-11eb-8738-38caa9d51767.png">
</details>

https://app.codecov.io/gh/yashaka/selene/pulls?page=1&state=open&order=-pullid
The way to fix it describes here:
https://community.codecov.io/t/how-to-fix-missing-base-report-on-open-source-project/1559/3
It's up version of codecov.