### PR TITLE
[#351] CHORE: web-driver manager update from 3.4.1 to 3.4.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -403,7 +403,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "webdriver-manager"
-version = "3.4.1"
+version = "3.4.2"
 description = "Library provides the way to automatically manage drivers for different browsers"
 category = "main"
 optional = false
@@ -437,7 +437,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e19f69b79bf05a147a9ec8236141c03ed0ea2b8546385ee14996139a27d055d2"
+content-hash = "65a658157c44a36ec8f1daa000e3010888014c1a7a9e68cc04a814cb3e59975a"
 
 [metadata.files]
 appdirs = [
@@ -726,8 +726,8 @@ urllib3 = [
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 webdriver-manager = [
-    {file = "webdriver_manager-3.4.1-py2.py3-none-any.whl", hash = "sha256:00bb38c91a1aee23ef09699df074f7328a3618abbe5bf23944b7e835ad561dd6"},
-    {file = "webdriver_manager-3.4.1.tar.gz", hash = "sha256:254a3c58a253785433ce0d8afd1d6a46ebf0e62137bb05a963c033958610c6da"},
+    {file = "webdriver_manager-3.4.2-py2.py3-none-any.whl", hash = "sha256:50a6e174106542f5335cacc387cec7ada26812babc1aeca61c208a1bab2ac2c5"},
+    {file = "webdriver_manager-3.4.2.tar.gz", hash = "sha256:c6d81590aae6fc0fb10cf7dd20c8c1b9bb043501f9cf62c316a854a0de841e32"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ packages = [
 python = "^3.7"
 selenium = "==3.141.0"
 future = "*"
-webdriver-manager = "==3.4.1"
+webdriver-manager = "==3.4.2"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
 Provides an update of Web-driver-manager for Selene from 3.4.1 to the  newest one  3.4.2  as issued 
> to #351 
> webdriver reliease changelog: can be found  [here](https://github.com/SergeyPirogov/webdriver_manager/compare/v3.4.2...master)