### PR TITLE
temporary disable new pylint version rules

### DIFF
--- a/.pylint-disabled-rules
+++ b/.pylint-disabled-rules
@@ -46,4 +46,6 @@ superfluous-parens,
 super-init-not-called,
 reimported,
 multiple-statements,
-E1120
+E1120,
+global-variable-not-assigned,
+consider-using-f-string


### PR DESCRIPTION
1. global-variable-not-assigned,
2. consider-using-f-string.