### PR TITLE
NEW: add config._wait_decorator

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Pycodestyle
         run: |
           pip install pycodestyle
-          pycodestyle $(pwd) --ignore=E501,W503,E402,E731 --exclude=.venv
+          pycodestyle $(pwd) --ignore=E501,W503,E402,E731,E203 --exclude=.venv
 
   Pylint:
     name: Lint Pylint

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 build
 skip-covered/
 tests/comparison/
-tests/adhoc/test_anything.py
+examples/test_anything.py
 custom.png
 
 # allure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,19 @@
   - should we make original config (not shared) mutable?
 - TODO: support python 3.10 [#393](https://github.com/yashaka/selene/issues/393)
 
-## 2.0.0b6 (to be released on xx.06.2022)
+## 2.0.0b7 (to be released on xx.09.2022)
 - TODO: trim text in have.exact_text
 
+## 2.0.0b7 (to be released on xx.08.2022)
+- NEW: added config._wait_decorator
+  - decorating Wait#for_ method 
+    - that is used when performing any element command 
+      and assertion (i.e. should)
+    - hence, can be used to log corresponding commands with waits
+      and integrate with something like allure reporting;)
+  - prefixed with underscore, indicating that method is experimental,
+    and can be e.g. renamed, etc.
+  - see example at [examples/log_all_selene_commands_with_wait.py](https://github.com/yashaka/selene/tree/master/examples/log_all_selene_commands_with_wait.py)
 
 ## 2.0.0b5 (to be released on 24.06.2022)
 - NEW: added command.js.*:

--- a/examples/log_all_selene_commands_with_wait.py
+++ b/examples/log_all_selene_commands_with_wait.py
@@ -1,0 +1,58 @@
+from selene import have
+from selene.support.shared import browser
+import logging
+
+log = logging.getLogger('SE')
+log.setLevel(20)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(name)s] - %(message)s")
+handler.setFormatter(formatter)
+log.addHandler(handler)
+
+
+def log_on_wait(for_):
+    def decorated(fn):
+        log.info('step: %s: STARTED', fn)
+        try:
+            res = for_(fn)
+            log.info('step: %s: ENDED', fn)
+            return res
+        except Exception as error:
+            log.info('step: %s: FAILED: %s', fn, error)
+            raise error
+
+    return decorated
+
+
+def test_logging_via__wait_decorator():
+    """
+        should log something like:
+
+    [SE] - step: type: a: STARTED
+    [SE] - step: type: a: ENDED
+    [SE] - step: press keys: ('\ue007',): STARTED
+    [SE] - step: press keys: ('\ue007',): ENDED
+    [SE] - step: type: b: STARTED
+    [SE] - step: type: b: ENDED
+    [SE] - step: press keys: ('\ue007',): STARTED
+    [SE] - step: press keys: ('\ue007',): ENDED
+    [SE] - step: type: c: STARTED
+    [SE] - step: type: c: ENDED
+    [SE] - step: press keys: ('\ue007',): STARTED
+    [SE] - step: press keys: ('\ue007',): ENDED
+    [SE] - step: has texts ('ab', 'b', 'c', 'd'): STARTED
+    [SE] - step: has texts ('ab', 'b', 'c', 'd'): FAILED: Message:
+
+    Timed out after 4s, while waiting for:browser.all(('css selector', '#todo-list>li')).has texts ('ab', 'b', 'c', 'd')
+    Reason: AssertionError: actual visible_texts: ['a', 'b', 'c']
+
+    """
+    browser.config._wait_decorator = log_on_wait
+
+    browser.open('http://todomvc.com/examples/emberjs/')
+
+    browser.element('#new-todo').type('a').press_enter()
+    browser.element('#new-todo').type('b').press_enter()
+    browser.element('#new-todo').type('c').press_enter()
+
+    browser.all('#todo-list>li').should(have.texts('ab', 'b', 'c', 'd'))

--- a/selene/core/entity.py
+++ b/selene/core/entity.py
@@ -271,6 +271,13 @@ class Element(WaitingEntity):
             extra_args,
         )
 
+    # def __execute_script__(
+    #     self,
+    #     script_on_self_element_and_args: str,
+    #     *extra_args,
+    # ):
+    #     return self._execute_script(script_on_self_element_and_args, *extra_args)
+
     def set_value(self, value: Union[str, int]) -> Element:
         # todo: should we move all commands like following or queries like in conditions - to separate py modules?
         # todo: should we make them webelement based (Callable[[WebElement], None]) instead of element based?

--- a/tests/acceptance/shared_browser/browser_management_test.py
+++ b/tests/acceptance/shared_browser/browser_management_test.py
@@ -6,12 +6,12 @@ from selene.support.shared import browser
 
 def test_shared_browser_not_reopen_on_action_after_been_closed():
     browser.open('https://duckduckgo.com/')
-    browser.element('[id="search_form_input_homepage"]').click()
+    browser.element('#search_form_input_homepage,#searchbox_input').click()
 
     browser.quit()
 
     with pytest.raises(RuntimeError) as error:
-        browser.element('[id="search_form_input_homepage"]').click()
+        browser.element('#search_form_input_homepage,#searchbox_input').click()
     assert 'Webdriver has been closed.' in str(error.value)
     assert 'You need to call open(url) to open a browser again.' in str(
         error.value
@@ -21,16 +21,18 @@ def test_shared_browser_not_reopen_on_action_after_been_closed():
 def test_shared_browser_starts_after_unexpectedly_closed_in_previous_test():
     browser.open('https://duckduckgo.com/')
 
-    browser.element('[id="search_form_input_homepage"]').click()
+    browser.element('#search_form_input_homepage,#searchbox_input').click()
 
-    browser.element('[id="search_form_input_homepage"]').should(be.visible)
+    browser.element('#search_form_input_homepage,#searchbox_input').should(
+        be.visible
+    )
 
 
 def test_shared_browser_reopens_on_url_open_action():
     browser.open('https://duckduckgo.com/')
-    browser.element('[id="search_form_input_homepage"]').click()
+    browser.element('#search_form_input_homepage,#searchbox_input').click()
 
     browser.quit()
     browser.open('https://duckduckgo.com/')
 
-    browser.element('[id="search_form_input_homepage"]').click()
+    browser.element('#search_form_input_homepage,#searchbox_input').click()

--- a/tests/examples/todomvc/straightforward_in_firefox/todomvc_test.py
+++ b/tests/examples/todomvc/straightforward_in_firefox/todomvc_test.py
@@ -32,32 +32,10 @@ def teardown_function():
     browser.config.browser_name = 'chrome'
 
 
-def test_filter_tasks():
-    browser.open('https://todomvc4tasj.herokuapp.com')
-    clear_completed_js_loaded = "return $._data($('#clear-completed').get(0), 'events').hasOwnProperty('click')"
-    browser.wait.for_(
-        have.js_returned(True, clear_completed_js_loaded),
-    )
+def test_add_todos():
+    browser.open('https://todomvc.com/examples/emberjs/')
 
     browser.element('#new-todo').set_value('a').press_enter()
     browser.element('#new-todo').set_value('b').press_enter()
     browser.element('#new-todo').set_value('c').press_enter()
     browser.all('#todo-list li').should(have.exact_texts('a', 'b', 'c'))
-
-    browser.all('#todo-list li').element_by(have.exact_text('b')).element(
-        '.toggle'
-    ).click()
-    browser.element(by.link_text('Active')).click()
-    browser.all('#todo-list li').filtered_by(be.visible).should(
-        have.exact_texts('a', 'c')
-    )
-
-    browser.element(by.link_text('Completed')).click()
-    browser.all('#todo-list li').filtered_by(be.visible).should(
-        have.exact_texts('b')
-    )
-
-    browser.element(by.link_text('All')).click()
-    browser.all('#todo-list li').filtered_by(be.visible).should(
-        have.exact_texts('a', 'b', 'c')
-    )

--- a/tests/integration/shared_browser/browser__config__wait_decorator_test.py
+++ b/tests/integration/shared_browser/browser__config__wait_decorator_test.py
@@ -1,0 +1,84 @@
+from selene import have
+from selene.support.shared import browser as selene_browser
+import logging
+
+
+class StringHandler(logging.Handler):
+    terminator = '\n'
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.stream = ''
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            # issue 35046: merged two stream.writes into one.
+            self.stream += msg + self.terminator
+        except Exception:
+            self.handleError(record)
+
+
+log = logging.getLogger('SE')
+log.setLevel(20)
+handler = StringHandler()
+formatter = logging.Formatter("[%(name)s] - %(message)s")
+handler.setFormatter(formatter)
+log.addHandler(handler)
+
+
+def log_on_wait(prefix):
+    def decorator(for_):
+        def decorated(fn):
+            log.info('%sstep: %s: STARTED', prefix, fn)
+            try:
+                res = for_(fn)
+                log.info('%sstep: %s: ENDED', prefix, fn)
+                return res
+            except Exception as error:
+                log.info('%sstep: %s: FAILED: %s', prefix, fn, error)
+                raise error
+
+        return decorated
+
+    return decorator
+
+
+def test_logging_via__wait_decorator():
+    browser = selene_browser.with_(_wait_decorator=log_on_wait('[1] - '))
+
+    browser.open('http://todomvc.com/examples/emberjs/')
+
+    browser.element('#new-todo').type('a').press_enter()
+    browser.with_(_wait_decorator=log_on_wait('[2] - ')).element(
+        '#new-todo'
+    ).type('b').press_enter()
+    browser.config._wait_decorator = log_on_wait('[4] - ')
+    browser.element('#new-todo').with_(
+        _wait_decorator=log_on_wait('[3] - ')
+    ).type('c').press_enter()
+
+    try:
+        browser.all('#todo-list>li').with_(timeout=0.3).should(
+            have.texts('ab', 'b', 'c', 'd')
+        )
+    except AssertionError:
+        assert (
+            r'''
+[SE] - [1] - step: type: a: STARTED
+[SE] - [1] - step: type: a: ENDED
+[SE] - [1] - step: press keys: ('\ue007',): STARTED
+[SE] - [1] - step: press keys: ('\ue007',): ENDED
+[SE] - [2] - step: type: b: STARTED
+[SE] - [2] - step: type: b: ENDED
+[SE] - [2] - step: press keys: ('\ue007',): STARTED
+[SE] - [2] - step: press keys: ('\ue007',): ENDED
+[SE] - [3] - step: type: c: STARTED
+[SE] - [3] - step: type: c: ENDED
+[SE] - [3] - step: press keys: ('\ue007',): STARTED
+[SE] - [3] - step: press keys: ('\ue007',): ENDED
+[SE] - [4] - step: has texts ('ab', 'b', 'c', 'd'): STARTED
+[SE] - [4] - step: has texts ('ab', 'b', 'c', 'd'): FAILED: Message:
+            '''.strip()
+            in handler.stream
+        )


### PR DESCRIPTION
- decorating Wait#for_ method
  - that is used when performing any element command
    and assertion (i.e. should)
  - hence, can be used to log corresponding commands with waits
    and integrate with something like allure reporting;)

- ignore E203 for pycodestyle, as it interferes with black

TODO:
- add example with logging to allure report
- consider wrapping driver.get inside browser.open as `self.wait.for_(Command(f'open {url}', lambda driver: driver.get(url))``
  - consider making it configurable via `config._wait_for_driver_get_in_browser_open` (True by default)