### PR TITLE
[#478] FIX: link condition element_is_selected to selenium is_selected()

### DIFF
--- a/selene/core/match.py
+++ b/selene/core/match.py
@@ -243,7 +243,9 @@ def element_has_attribute(name: str):
     )
 
 
-element_is_selected: Condition[Element] = element_has_attribute('elementIsSelected')
+element_is_selected: Condition[Element] = ElementCondition.raise_if_not(
+    'is selected', lambda element: element().is_selected()
+)
 
 
 def element_has_value(expected: str) -> Condition[Element]:


### PR DESCRIPTION
adjusting the `element_is_selected` condition so that it calls the Selenium element's `is_selected()` method, instead of looking for the attribute `elementIsSelected`.

Closes #478