### PR TITLE
[#491] CHORE: Update typing-extensions dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1607,13 +1607,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]
@@ -1808,4 +1808,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "2110642827d2cdd7e6212eb8cdf459b929669614f5b553f6602e62b2e0a0d874"
+content-hash = "1b7c7e0b23c580e8a1fe8a53237e76e73500d18af21942278da60969fbd71684"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ python = "^3.7"
 selenium = ">=4.4.3"
 future = "*"
 webdriver-manager = "==3.8.6"
-typing-extensions = "==4.3.0"
+typing-extensions = ">=4.6.1"
 
 [tool.poetry.dev-dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
Loosen version dependency for `typing-extentions` to `>=4.6.1` to be able to use latest pydantic 2 in our projects

Closes #491 