### PR TITLE
[#513] FIX: Fix error message thrown by selenium exceptions upon wait

### DIFF
--- a/selene/core/wait.py
+++ b/selene/core/wait.py
@@ -119,11 +119,9 @@ class Wait(Generic[E]):
                     return fn(self.entity)
                 except Exception as reason:
                     if time.time() > finish_time:
-                        reason_message = str(reason)
-
                         reason_string = '{name}: {message}'.format(
                             name=reason.__class__.__name__,
-                            message=reason_message,
+                            message=getattr(reason, "msg", str(reason)),
                         )
                         # TODO: think on how can we improve logging failures in selene, e.g. reverse msg and stacktrace
                         # stacktrace = getattr(reason, 'stacktrace', None)

--- a/tests/integration/browser__actions_test.py
+++ b/tests/integration/browser__actions_test.py
@@ -148,7 +148,7 @@ def test_browser_actions_fails_to_wait_for_drag_and_drop_before_perform(
         assert (
             "browser.element(('css selector', '#draggable')).locate webelement\n"
             "\n"
-            "Reason: NoSuchElementException: Message: "
+            "Reason: NoSuchElementException: "
             "no such element: Unable to locate element: "
             "{\"method\":\"css selector\",\"selector\":\"#draggable\"}\n"
         ) in str(error)

--- a/tests/integration/element__type_test.py
+++ b/tests/integration/element__type_test.py
@@ -161,7 +161,7 @@ def test_type_failure_when_invisible(session_browser):
         assert time_spent >= 1
         browser.element('#text-field').should(have.value('before'))
         assert (
-            'Reason: JavascriptException: Message: javascript error: '
+            'Reason: JavascriptException: javascript error: '
             'element '
             '<input id="text-field" value="before" style="display: none"> '
             'is not visible\n'

--- a/tests/integration/error_messages_test.py
+++ b/tests/integration/error_messages_test.py
@@ -92,9 +92,10 @@ def test_element_search_fails_with_message_when_implicitly_waits_for_condition(
         'Timed out after 0.1s, while waiting for:',
         "browser.element(('css selector', '#hidden-button')).click",
         '',
-        'Reason: ElementNotInteractableException: Message: element not interactable',
+        'Reason: ElementNotInteractableException: element not interactable',
         '(Session info: *)',
-        'Stacktrace: *',
+        'Screenshot: *.png',
+        'PageSource: *.html',
     ]
 
 
@@ -119,9 +120,10 @@ def test_inner_element_search_fails_with_message_when_implicitly_waits_for_condi
         "browser.element(('css selector', '#container')).element(('css selector', "
         "'#hidden-button')).click",
         '',
-        'Reason: ElementNotInteractableException: Message: element not interactable',
+        'Reason: ElementNotInteractableException: element not interactable',
         '(Session info: *)',
-        'Stacktrace: *',
+        'Screenshot: *.png',
+        'PageSource: *.html',
     ]
 
 
@@ -146,9 +148,10 @@ def test_inner_element_search_fails_with_message_when_implicitly_waits_for_condi
         "browser.element(('css selector', '#hidden-container')).element(('css "
         "selector', '#button')).click",
         '',
-        'Reason: ElementNotInteractableException: Message: element not interactable',
+        'Reason: ElementNotInteractableException: element not interactable',
         '(Session info: *)',
-        'Stacktrace: *',
+        'Screenshot: *.png',
+        'PageSource: *.html',
     ]
 
 
@@ -173,11 +176,12 @@ def test_inner_element_search_fails_with_message_when_implicitly_waits_for_condi
         "browser.element(('css selector', '#not-existing')).element(('css selector', "
         "'#button')).click",
         '',
-        'Reason: NoSuchElementException: Message: no such element: Unable to locate '
+        'Reason: NoSuchElementException: no such element: Unable to locate '
         'element: {"method":"css selector","selector":"#not-existing"}',
         '(Session info: *); For documentation on this error, please visit: '
         'https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception',
-        'Stacktrace: *',
+        'Screenshot: *.png',
+        'PageSource: *.html',
     ]
 
 


### PR DESCRIPTION
Currently we were casting entire exception to the string (including not readable stacktrace) from selenium to error message. Instead, we should pass just the error message.

Before:

```
.venv/lib/python3.8/site-packages/selene/core/wait.py:143: in for_
     return self._decorator(self)(logic)(fn)
 .venv/lib/python3.8/site-packages/selene/core/wait.py:141: in logic
     raise self._hook_failure(failure)
 E   selene.core.exceptions.TimeoutException: Message: 
 E   
 E   Timed out after 1s, while waiting for:
 E   browser.element(('id', 'UserName')).is present in DOM
 E   
 E   Reason: NoSuchElementException: Message: no such element: Unable to locate element: {"method":"css selector","selector":"[id="UserName"]"}
 E     (Session info: chrome=121.0.6167.160); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception
 E   Stacktrace:
 E   0   chromedriver                        0x00000001009c0168 chromedriver + 4673896
 E   1   chromedriver                        0x00000001009b79c3 chromedriver + 4639171
 E   2   chromedriver                        0x00000001005abfdd chromedriver + 397277
 E   3   chromedriver                        0x00000001005f7bfc chromedriver + 707580
 E   4   chromedriver                        0x00000001005f7dd1 chromedriver + 708049
 E   5   chromedriver                        0x000000010063c284 chromedriver + 987780
 E   6   chromedriver                        0x000000010061a8ed chromedriver + 850157
 E   7   chromedriver                        0x0000000100639796 chromedriver + 976790
 E   8   chromedriver                        0x000000010061a663 chromedriver + 849507
 E   9   chromedriver                        0x00000001005ea1cf chromedriver + 651727
 E   10  chromedriver                        0x00000001005eb1ae chromedriver + 655790
 E   11  chromedriver                        0x0000000100980380 chromedriver + 4412288
 E   12  chromedriver                        0x0000000100985798 chromedriver + 4433816
 E   13  chromedriver                        0x0000000100964d71 chromedriver + 4300145
 E   14  chromedriver                        0x00000001009864e6 chromedriver + 4437222
 E   15  chromedriver                        0x0000000100956d3c chromedriver + 4242748
 E   16  chromedriver                        0x00000001009a6208 chromedriver + 4567560
 E   17  chromedriver                        0x00000001009a63be chromedriver + 4567998
 E   18  chromedriver                        0x00000001009b7603 chromedriver + 4638211
 E   19  libsystem_pthread.dylib             0x00007ff805e53202 _pthread_start + 99
 E   20  libsystem_pthread.dylib             0x00007ff805e4ebab thread_start + 15
```

After:
```
.venv/lib/python3.8/site-packages/selene/core/wait.py:141: in for_
     return self._decorator(self)(logic)(fn)
 .venv/lib/python3.8/site-packages/selene/core/wait.py:139: in logic
     raise self._hook_failure(failure)
 E selene.core.exceptions.TimeoutException: Message: 
 E   
 E Timed out after 1s, while waiting for:
 E browser.element(('id', 'UserName')).is present in DOM
 E   
 E Reason: NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"[id="UserName"]"}
 E (Session info: chrome=121.0.6167.160); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception
```