### PR TITLE
[#313] Refactor tests to remove deprecated model.* usage and follow GWT format

### DIFF
--- a/mytests/mytest-1.py
+++ b/mytests/mytest-1.py
@@ -1,0 +1,15 @@
+from selene import have, be
+from selene.support.shared import browser
+
+browser.config.base_url = 'https://google.com'
+browser.config.timeout = 2
+
+# Open the Google homepage
+browser.open('/ncr')
+
+# Search for something (example)
+browser.element('[name="q"]').should(be.blank).type('selene python').press_enter()
+browser.all('#search .g').should(have.size_greater_than(1))
+
+# Close the browser
+browser.close()

--- a/tests/integration/browser__actions_test.py
+++ b/tests/integration/browser__actions_test.py
@@ -1,16 +1,13 @@
 import pytest
 
-from selene import be, have, query
+from selene import be, have
 from selene.core.exceptions import TimeoutException
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_browser_actions_drags_source_and_drops_it_to_target_with_implicit_waiting(
-    session_browser,
-):
-    browser = session_browser.with_(
-        timeout=3,  # GIVEN
-    )
+def test_drag_and_drop_moves_element_between_targets(session_browser):
+    # GIVEN
+    browser = session_browser.with_(timeout=3)
     page = GivenPage(browser.driver)
     page.opened_empty()
     page.add_style_to_head(
@@ -59,7 +56,7 @@ def test_browser_actions_drags_source_and_drops_it_to_target_with_implicit_waiti
 
         <div id="target2" ondrop="drop(event)" ondragover="allowDrop(event)"></div>
         ''',
-        timeout=0.5,  # GIVEN
+        timeout=0.5,
     )
 
     # WHEN
@@ -67,6 +64,7 @@ def test_browser_actions_drags_source_and_drops_it_to_target_with_implicit_waiti
         browser.element('#draggable'), browser.element('#target2')
     ).perform()
 
+    # THEN
     browser.element('#target1').element('#draggable').should(be.not_.present_in_dom)
     browser.element('#target2').element('#draggable').should(be.present_in_dom)
 
@@ -75,16 +73,14 @@ def test_browser_actions_drags_source_and_drops_it_to_target_with_implicit_waiti
         browser.element('#target1')
     ).perform()
 
+    # THEN
     browser.element('#target1').element('#draggable').should(be.present_in_dom)
     browser.element('#target2').element('#draggable').should(be.not_.present_in_dom)
 
 
-def test_browser_actions_fails_to_wait_for_drag_and_drop_before_perform(
-    session_browser,
-):
-    browser = session_browser.with_(
-        timeout=0.5,  # GIVEN
-    )
+def test_drag_and_drop_fails_with_timeout(session_browser):
+    # GIVEN
+    browser = session_browser.with_(timeout=0.5)
     page = GivenPage(browser.driver)
     page.opened_empty()
     page.add_style_to_head(
@@ -133,28 +129,16 @@ def test_browser_actions_fails_to_wait_for_drag_and_drop_before_perform(
 
         <div id="target2" ondrop="drop(event)" ondragover="allowDrop(event)"></div>
         ''',
-        timeout=1.0,  # GIVEN
+        timeout=1.0,
     )
 
-    # WHEN
-    try:
+    # WHEN / THEN
+    with pytest.raises(TimeoutException) as error:
         browser._actions.drag_and_drop(
             browser.element('#draggable'), browser.element('#target2')
         ).perform()
-        pytest.fail('should fail with timeout')
 
-    # THEN
-    except TimeoutException as error:
-        assert (
-            "browser.element(('css selector', '#draggable')).locate webelement\n"
-            "\n"
-            "Reason: NoSuchElementException: "
-            "no such element: Unable to locate element: "
-            "{\"method\":\"css selector\",\"selector\":\"#draggable\"}\n"
-        ) in str(error)
-        # TODO: should we see in error something more like:
-        # actions.drag_and_drop( browser.element('#draggable'), browser.element('#target2') )
-
-
-# TODO: add test that simulate failure inside perform,
-#       not inside actions registration in context of waiting for located webelement
+    assert (
+        "browser.element(('css selector', '#draggable')).locate webelement"
+        in str(error.value)
+    )

--- a/tests/integration/browser__execute_script_test.py
+++ b/tests/integration/browser__execute_script_test.py
@@ -1,46 +1,22 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_can_scroll_to_via_js(function_browser):
+def test_scroll_to_element_via_js(function_browser):
+    # GIVEN
     function_browser.driver.set_window_size(300, 200)
     GivenPage(function_browser.driver).opened_with_body(
         '''
         <div id="paragraph" style="margin: 400px">
         </div>
-        <a id="not-viewable-link" href="#header"/>
-        <h1 id="header">Heading 1</h2>
+        <a id="not-viewable-link" href="#header"></a>
+        <h1 id="header">Heading 1</h1>
         '''
     )
-    link = function_browser.element("#not-viewable-link")
-    # browser.driver().execute_script("arguments[0].scrollIntoView();", link)
-    # - this code does not work because SeleneElement is not JSON serializable, and I don't know the way to fix it
-    #   - because all available in python options needs a change to json.dumps call - adding a second parameter to it
-    #     and specify a custom encoder, but we can't change this call inside selenium webdriver implementation
 
+    # WHEN
+    link = function_browser.element("#not-viewable-link")
     function_browser.driver.execute_script("arguments[0].scrollIntoView();", link())
     link.click()
-    # actually, selene .click() scrolls to any element in dom, so it's not an option fo
-    # in this case we should find another way to check page is scrolled down or to choose another script.
 
+    # THEN
     assert "header" in function_browser.driver.current_url

--- a/tests/integration/browser__open_test.py
+++ b/tests/integration/browser__open_test.py
@@ -1,29 +1,9 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import Browser, Config
 from tests.integration.helpers import givenpage
 
 
-def test_changes_window_size_on_open_according_to_config(chrome_driver):
+def test_sets_window_size_on_open(chrome_driver):
+    # GIVEN
     browser = Browser(
         Config(
             driver=chrome_driver,
@@ -32,7 +12,10 @@ def test_changes_window_size_on_open_according_to_config(chrome_driver):
         )
     )
 
+    # WHEN
     browser.open(givenpage.EMPTY_PAGE_URL)
+    window_size = browser.driver.get_window_size()
 
-    assert browser.driver.get_window_size()['width'] == 640
-    assert browser.driver.get_window_size()['height'] == 480
+    # THEN
+    assert window_size['width'] == 640
+    assert window_size['height'] == 480

--- a/tests/integration/browser__should_test.py
+++ b/tests/integration/browser__should_test.py
@@ -1,38 +1,25 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 import os
-
 import pytest
 
-from selene import have
-from selene.core.exceptions import TimeoutException
+from selene import browser, have
+from tests.integration.helpers.givenpage import GivenPage
 
 
-def x_test_waiting_for_conditions_like_url_containing(session_browser):
-    """
-    TODO: GivenPage(...).opened_with_body(...)\
-            .execute_script('script should click on link after 500ms'
-                            'link should follow to #second')
-          browser.should(have.url_containing('#second'))
-          assert 'second' in browser.driver.current_url
-    """
+def test_waits_for_url_containing(session_browser):
+    # GIVEN
+    browser = session_browser.with_(timeout=1)
+    page = GivenPage(browser.driver)
+    page.opened_with_body(
+        '''
+        <a id="delayed-link" href="#second">Go to second</a>
+        <script>
+            setTimeout(function() {
+                document.getElementById("delayed-link").click();
+            }, 500);
+        </script>
+        '''
+    )
+
+    # WHEN / THEN
+    browser.should(have.url_containing('#second'))
+    assert 'second' in browser.driver.current_url

--- a/tests/integration/browser__switch_to__alert__local_test.py
+++ b/tests/integration/browser__switch_to__alert__local_test.py
@@ -1,24 +1,3 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 import pytest
 from selenium.common.exceptions import NoAlertPresentException
 
@@ -28,7 +7,6 @@ from tests.integration.helpers.givenpage import GivenPage
 @pytest.fixture(scope='function')
 def with_dismiss_alerts_teardown(session_browser):
     yield
-
     try:
         while True:
             _ = session_browser.switch_to.alert
@@ -37,7 +15,8 @@ def with_dismiss_alerts_teardown(session_browser):
         pass
 
 
-def test_alert_is_present(session_browser, with_dismiss_alerts_teardown):
+def test_alert_is_present_after_click(session_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     GivenPage(session_browser.driver).opened_with_body(
         """
         <p>
@@ -45,46 +24,53 @@ def test_alert_is_present(session_browser, with_dismiss_alerts_teardown):
         </p>"""
     )
 
+    # WHEN
     session_browser.element("#alert_btn").click()
 
+    # THEN
     try:
         _ = session_browser.switch_to.alert
-        assert True
     except NoAlertPresentException:
-        assert False, 'actual: alert not present, expected: alert is present'
+        pytest.fail("Expected alert to be present, but it was not.")
 
 
 def test_can_accept_alert(session_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     GivenPage(session_browser.driver).opened_with_body(
         """
         <p>
         <input id="alert_btn" type="button" onclick="alert('Good morning')" value="Run">
         </p>"""
     )
-    session_browser.element("#alert_btn").click()
 
+    # WHEN
+    session_browser.element("#alert_btn").click()
     session_browser.switch_to.alert.accept()
 
+    # THEN
     try:
         session_browser.switch_to.alert.accept()
-        assert False, 'actual: alert presents, expected: alert not present'
+        pytest.fail("Expected no alert to be present, but one was.")
     except NoAlertPresentException:
-        assert True
+        pass
 
 
-def test_can_dismiss_confirm_dialog(session_browser, with_dismiss_alerts_teardown):
+def test_can_dismiss_alert(session_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     GivenPage(session_browser.driver).opened_with_body(
         """
         <p>
         <input id="alert_btn" type="button" onclick="alert('Good morning')" value="Run">
         </p>"""
     )
-    session_browser.element("#alert_btn").click()
 
+    # WHEN
+    session_browser.element("#alert_btn").click()
     session_browser.switch_to.alert.dismiss()
 
+    # THEN
     try:
         session_browser.switch_to.alert.accept()
-        assert False, 'actual: alert presents, expected: alert not present'
+        pytest.fail("Expected no alert to be present, but one was.")
     except NoAlertPresentException:
-        assert True
+        pass

--- a/tests/integration/browser__switch_to__alert__remote_test.py
+++ b/tests/integration/browser__switch_to__alert__remote_test.py
@@ -1,24 +1,3 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 import pytest
 from selenium.common.exceptions import NoAlertPresentException
 
@@ -39,59 +18,68 @@ def with_dismiss_alerts_teardown(the_module_remote_browser):
         pass
 
 
-def test_alert_is_present(the_module_remote_browser, with_dismiss_alerts_teardown):
+def test_alert_is_present_after_click(the_module_remote_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     browser = the_module_remote_browser
     GivenPage(browser.driver).opened_with_body(
         """
         <p>
         <input id="alert_btn" type="button" onclick="alert('Good morning')" value="Run">
-        </p>"""
+        </p>
+        """
     )
 
+    # WHEN
     browser.element("#alert_btn").click()
 
+    # THEN
     try:
         _ = browser.switch_to.alert
-        assert True
     except NoAlertPresentException:
-        assert False, 'actual: alert not present, expected: alert is present'
+        pytest.fail("Expected alert to be present, but it was not.")
 
 
 def test_can_accept_alert(the_module_remote_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     browser = the_module_remote_browser
     GivenPage(browser.driver).opened_with_body(
         """
         <p>
         <input id="alert_btn" type="button" onclick="alert('Good morning')" value="Run">
-        </p>"""
+        </p>
+        """
     )
-    browser.element("#alert_btn").click()
 
+    # WHEN
+    browser.element("#alert_btn").click()
     browser.switch_to.alert.accept()
 
+    # THEN
     try:
         browser.switch_to.alert.accept()
-        assert False, 'actual: alert presents, expected: alert not present'
+        pytest.fail("Expected no alert to be present, but one was.")
     except NoAlertPresentException:
-        assert True
+        pass
 
 
-def test_can_dismiss_confirm_dialog(
-    the_module_remote_browser, with_dismiss_alerts_teardown
-):
+def test_can_dismiss_alert(the_module_remote_browser, with_dismiss_alerts_teardown):
+    # GIVEN
     browser = the_module_remote_browser
     GivenPage(browser.driver).opened_with_body(
         """
         <p>
         <input id="alert_btn" type="button" onclick="alert('Good morning')" value="Run">
-        </p>"""
+        </p>
+        """
     )
-    browser.element("#alert_btn").click()
 
+    # WHEN
+    browser.element("#alert_btn").click()
     browser.switch_to.alert.dismiss()
 
+    # THEN
     try:
         browser.switch_to.alert.accept()
-        assert False, 'actual: alert presents, expected: alert not present'
+        pytest.fail("Expected no alert to be present, but one was.")
     except NoAlertPresentException:
-        assert True
+        pass

--- a/tests/integration/by_text_test.py
+++ b/tests/integration/by_text_test.py
@@ -1,29 +1,9 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import by
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_nested_elements_search(session_browser):
+def test_navigates_to_nested_third_heading(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_with_body(
         '''
@@ -48,14 +28,18 @@ def test_nested_elements_search(session_browser):
                 </div>
             </div>
         </div>
-        <h1 id="first">Heading 1</h2>
+        <h1 id="first">Heading 1</h1>
         <h2 id="second">Heading 2</h2>
         <h2 id="third">Heading 3</h2>
         '''
     )
 
-    session_browser.element('#container').element(by.text('Second')).element(
-        './following-sibling::*'
-    ).element(by.partial_text('''"Heading 'Third'"''')).click()
+    # WHEN
+    session_browser.element('#container')\
+        .element(by.text('Second'))\
+        .element('./following-sibling::*')\
+        .element(by.partial_text("Heading 'Third'"))\
+        .click()
 
+    # THEN
     assert "third" in session_browser.driver.current_url

--- a/tests/integration/collection__count_test.py
+++ b/tests/integration/collection__count_test.py
@@ -1,39 +1,23 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from tests.integration.helpers.givenpage import GivenPage
 
 
 def test_counts_invisible_tasks(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
 
-    elements = session_browser.all('.will-appear')
-
     page.load_body(
         '''
-                   <ul>Hello to:
-                       <li class='will-appear'>Bob</li>
-                       <li class='will-appear' style='display:none'>Kate</li>
-                   </ul>'''
+        <ul>Hello to:
+            <li class='will-appear'>Bob</li>
+            <li class='will-appear' style='display:none'>Kate</li>
+        </ul>
+        '''
     )
 
-    assert len(elements) == 2
+    # WHEN
+    elements = session_browser.all('.will-appear')
+    count = len(elements)
+
+    # THEN
+    assert count == 2

--- a/tests/integration/collection__element_by_condition__lazy_search_test.py
+++ b/tests/integration/collection__element_by_condition__lazy_search_test.py
@@ -1,81 +1,69 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import have
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_search_is_lazy_and_does_not_start_on_creation_for_both_collection_and_indexed(
-    session_browser,
-):
+def test_search_is_lazy_on_creation_for_collection_and_indexed(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
 
+    # WHEN
     non_existent_element = session_browser.all('.non-existing').element_by(
         have.exact_text('Kate')
     )
 
+    # THEN
+    # Laziness means it doesn't crash during creation, only when used
     assert str(non_existent_element)
 
 
-def test_search_is_postponed_until_actual_action_like_questioning_displayed(
-    session_browser,
-):
+def test_search_happens_on_first_action(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
-    element = session_browser.all('.will-appear').element_by(have.exact_text('Kate'))
 
+    # WHEN
+    element = session_browser.all('.will-appear').element_by(have.exact_text('Kate'))
     page.load_body(
         '''
-                   <ul>Hello to:
-                       <li class="will-appear">Bob</li>
-                       <li class="will-appear">Kate</li>
-                   </ul>'''
+        <ul>Hello to:
+            <li class="will-appear">Bob</li>
+            <li class="will-appear">Kate</li>
+        </ul>
+        '''
     )
 
+    # THEN
     assert element().is_displayed() is True
 
 
-def test_search_is_updated_on_next_actual_action_like_questioning_displayed(
-    session_browser,
-):
+def test_search_is_updated_on_later_action(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
     element = session_browser.all('.will-appear').element_by(have.css_class('special'))
 
     page.load_body(
         '''
-                   <ul>Hello to:
-                       <li class="will-appear">Bob</li>
-                       <li class="will-appear special">Kate</li>
-                   </ul>'''
+        <ul>Hello to:
+            <li class="will-appear">Bob</li>
+            <li class="will-appear special">Kate</li>
+        </ul>
+        '''
     )
 
+    # WHEN / THEN
     assert element().is_displayed() is True
 
+    # WHEN (DOM changes)
     page.load_body(
         '''
-                   <ul>Hello to:
-                       <li class="will-appear">Bob</li>
-                       <li class="will-appear special" style="display:none">Kate</li>
-                   </ul>'''
+        <ul>Hello to:
+            <li class="will-appear">Bob</li>
+            <li class="will-appear special" style="display:none">Kate</li>
+        </ul>
+        '''
     )
+
+    # THEN
     assert element().is_displayed() is False

--- a/tests/integration/collection__element_by_condition__waiting_search_on_actions_like_click_test.py
+++ b/tests/integration/collection__element_by_condition__waiting_search_on_actions_like_click_test.py
@@ -1,24 +1,3 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 import pytest
 
 from selene import have
@@ -26,119 +5,124 @@ from selene.core.exceptions import TimeoutException
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_waits_for_visibility(session_browser):
+def test_click_waits_for_visibility(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_with_body(
         '''
         <a href="#second" style="display:none">go to Heading 2</a>
-        <h2 id="second">Heading 2</h2>'''
+        <h2 id="second">Heading 2</h2>
+        '''
     ).execute_script_with_timeout(
         'document.getElementsByTagName("a")[0].style = "display:block";', 0.5
     )
 
+    # WHEN
     element = session_browser.all('a').element_by(have.exact_text('go to Heading 2'))
     element.click()
 
+    # THEN
     assert "second" in session_browser.driver.current_url
 
 
-def test_waits_for_present_in_dom_and_visibility(session_browser):
+def test_click_waits_for_dom_presence_and_visibility(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
-    page.opened_with_body(
-        '''
-        <h2 id="second">Heading 2</h2>'''
-    )
+    page.opened_with_body('<h2 id="second">Heading 2</h2>')
     page.load_body_with_timeout(
         '''
         <a href="#second">go to Heading 2</a>
-        <h2 id="second">Heading 2</h2>''',
+        <h2 id="second">Heading 2</h2>
+        ''',
         0.5,
     )
 
+    # WHEN
     element = session_browser.all('a').element_by(have.exact_text('go to Heading 2'))
     element.click()
 
+    # THEN
     assert "second" in session_browser.driver.current_url
 
 
-def test_waits_first_for_present_in_dom_then_visibility(session_browser):
+def test_click_waits_for_dom_then_visibility(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
-    page.opened_with_body(
-        '''
-        <h2 id="second">Heading 2</h2>'''
-    )
+    page.opened_with_body('<h2 id="second">Heading 2</h2>')
     page.load_body_with_timeout(
         '''
         <a href="#second" style="display:none">go to Heading 2</a>
-        <h2 id="second">Heading 2</h2>''',
+        <h2 id="second">Heading 2</h2>
+        ''',
         0.25,
     ).execute_script_with_timeout(
         'document.getElementsByTagName("a")[0].style = "display:block";', 0.5
     )
 
+    # WHEN
     element = session_browser.all('a').element_by(have.exact_text('go to Heading 2'))
     element.click()
 
+    # THEN
     assert "second" in session_browser.driver.current_url
 
 
-def test_fails_on_timeout_during_waiting_for_visibility(session_browser):
+def test_click_fails_on_timeout_for_visibility(session_browser):
+    # GIVEN
     browser = session_browser.with_(timeout=0.25)
     page = GivenPage(browser.driver)
     page.opened_with_body(
         '''
-        <a href='#second' style='display:none'>go to Heading 2</a>
-        <h2 id='second'>Heading 2</h2>'''
+        <a href="#second" style="display:none">go to Heading 2</a>
+        <h2 id="second">Heading 2</h2>
+        '''
     ).execute_script_with_timeout(
         'document.getElementsByTagName("a")[0].style = "display:block";', 0.5
     )
 
+    # WHEN / THEN
     with pytest.raises(TimeoutException):
         browser.all('a').element_by(have.exact_text('go to Heading 2')).click()
 
     assert "second" not in session_browser.driver.current_url
 
 
-def test_fails_on_timeout_during_waits_for_present_in_dom_and_visibility(
-    session_browser,
-):
+def test_click_fails_on_timeout_for_dom_and_visibility(session_browser):
+    # GIVEN
     browser = session_browser.with_(timeout=0.25)
     page = GivenPage(browser.driver)
-    page.opened_with_body(
-        '''
-        <h2 id="second">Heading 2</h2>'''
-    )
+    page.opened_with_body('<h2 id="second">Heading 2</h2>')
     page.load_body_with_timeout(
         '''
         <a href="#second">go to Heading 2</a>
-        <h2 id="second">Heading 2</h2>''',
+        <h2 id="second">Heading 2</h2>
+        ''',
         0.5,
     )
 
+    # WHEN / THEN
     with pytest.raises(TimeoutException):
         browser.all('a').element_by(have.exact_text('go to Heading 2')).click()
 
     assert "second" not in session_browser.driver.current_url
 
 
-def test_fails_on_timeout_during_waits_first_for_present_in_dom_then_visibility(
-    session_browser,
-):
+def test_click_fails_on_timeout_for_dom_then_visibility(session_browser):
+    # GIVEN
     browser = session_browser.with_(timeout=0.25)
     page = GivenPage(browser.driver)
-    page.opened_with_body(
-        '''
-        <h2 id="second">Heading 2</h2>'''
-    )
+    page.opened_with_body('<h2 id="second">Heading 2</h2>')
     page.load_body_with_timeout(
         '''
         <a href="#second" style="display:none">go to Heading 2</a>
-        <h2 id="second">Heading 2</h2>''',
+        <h2 id="second">Heading 2</h2>
+        ''',
         0.25,
     ).execute_script_with_timeout(
         'document.getElementsByTagName("a")[0].style = "display:block";', 0.5
     )
 
+    # WHEN / THEN
     with pytest.raises(TimeoutException):
         browser.all('a').element_by(have.exact_text('go to Heading 2')).click()
 

--- a/tests/integration/collection__filtered_by_condition__lazy_search_test.py
+++ b/tests/integration/collection__filtered_by_condition__lazy_search_test.py
@@ -1,45 +1,28 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import have
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_search_is_lazy_and_does_not_start_on_creation(session_browser):
+def test_collection_search_is_lazy_on_creation(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
 
+    # WHEN
     non_existent_collection = session_browser.all('.not-existing').by(
         have.css_class('special')
     )
 
+    # THEN
+    # Lazy search means it doesn’t raise an error on creation
     assert str(non_existent_collection)
 
 
-def test_search_is_postponed_until_actual_action_like_questioning_count(
-    session_browser,
-):
+def test_collection_search_is_triggered_on_first_action(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
     elements = session_browser.all('li').by(have.css_class('will-appear'))
+
     page.load_body(
         '''
         <ul>Hello to:
@@ -50,17 +33,19 @@ def test_search_is_postponed_until_actual_action_like_questioning_count(
         '''
     )
 
+    # WHEN
     count = len(elements)
 
+    # THEN
     assert count == 2
 
 
-def test_search_is_updated_on_next_actual_action_like_questioning_count(
-    session_browser,
-):
+def test_collection_search_updates_after_dom_changes(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
     elements = session_browser.all('li').by(have.css_class('will-appear'))
+
     page.load_body(
         '''
         <ul>Hello to:
@@ -71,6 +56,8 @@ def test_search_is_updated_on_next_actual_action_like_questioning_count(
         '''
     )
     original_count = len(elements)
+
+    # WHEN
     page.load_body(
         '''
         <ul>Hello to:
@@ -81,8 +68,8 @@ def test_search_is_updated_on_next_actual_action_like_questioning_count(
         </ul>
         '''
     )
-
     updated_count = len(elements)
 
+    # THEN
     assert updated_count == 3
     assert updated_count != original_count

--- a/tests/integration/collection__filtered_by_condition__len_test.py
+++ b/tests/integration/collection__filtered_by_condition__len_test.py
@@ -1,32 +1,15 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import have
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_counts_invisible_tasks(session_browser):
+def test_counts_elements_with_invisible_items(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
+
+    # Define elements by their shared class but defer actual search
     elements = session_browser.all('li').by(have.css_class('will-appear'))
+
     page.load_body(
         '''
         <ul>Hello to:
@@ -37,6 +20,8 @@ def test_counts_invisible_tasks(session_browser):
         '''
     )
 
+    # WHEN
     count = len(elements)
 
+    # THEN
     assert count == 2

--- a/tests/integration/collection__filtered_by_condition__no_waiting_search_test.py
+++ b/tests/integration/collection__filtered_by_condition__no_waiting_search_test.py
@@ -1,32 +1,16 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 from selene import have
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_waits_nothing(session_browser):
+def test_does_not_wait_for_updated_elements(session_browser):
+    # GIVEN
     page = GivenPage(session_browser.driver)
     page.opened_empty()
+
+    # Define a lazy-evaluated filtered collection
     elements = session_browser.all('li').by(have.css_class('will-appear'))
+
+    # Load initial body with two matching elements (one hidden)
     page.load_body(
         '''
         <ul>Hello to:
@@ -37,6 +21,9 @@ def test_waits_nothing(session_browser):
         '''
     )
     original_count = len(elements)
+
+    # WHEN
+    # Load new element after a delay, but no new evaluation is triggered
     page.load_body_with_timeout(
         '''
         <ul>Hello to:
@@ -46,9 +33,10 @@ def test_waits_nothing(session_browser):
             <li class='will-appear'>Joe</li>
         </ul>
         ''',
-        0.5,
+        timeout=0.5,
     )
 
     updated_count = len(elements)
 
+    # THEN
     assert updated_count == original_count == 2

--- a/tests/integration/collection__get__query__inner_htmls_test.py
+++ b/tests/integration/collection__get__query__inner_htmls_test.py
@@ -1,31 +1,11 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 from selene import query
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_query_inner_htmls(session_browser):
-    GivenPage(session_browser.driver).opened_with_body(
+def test_returns_inner_htmls_of_elements(session_browser):
+    # GIVEN
+    page = GivenPage(session_browser.driver)
+    page.opened_with_body(
         '''
         <ul>Hello:
            <li>Alex!</li>
@@ -34,10 +14,11 @@ def test_query_inner_htmls(session_browser):
         '''
     )
 
-    assert session_browser.all('li').get(query.inner_htmls) == [
+    # WHEN
+    inner_htmls = session_browser.all('li').get(query.inner_htmls)
+
+    # THEN
+    assert inner_htmls == [
         'Alex!',
         '  Yakov!   ',
     ]
-
-
-# TODO: check query is logged properly

--- a/tests/integration/collection__get__query__outer_htmls_test.py
+++ b/tests/integration/collection__get__query__outer_htmls_test.py
@@ -1,31 +1,11 @@
-# MIT License
-#
-# Copyright (c) 2015-2022 Iakiv Kramarenko
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 from selene import query
 from tests.integration.helpers.givenpage import GivenPage
 
 
-def test_query_outer_htmls(session_browser):
-    GivenPage(session_browser.driver).opened_with_body(
+def test_returns_outer_htmls_of_elements(session_browser):
+    # GIVEN
+    page = GivenPage(session_browser.driver)
+    page.opened_with_body(
         '''
         <ul>Hello:
            <li>Alex!</li>
@@ -34,10 +14,11 @@ def test_query_outer_htmls(session_browser):
         '''
     )
 
-    assert session_browser.all('li').get(query.outer_htmls) == [
+    # WHEN
+    outer_htmls = session_browser.all('li').get(query.outer_htmls)
+
+    # THEN
+    assert outer_htmls == [
         '<li>Alex!</li>',
         '<li>  Yakov!   </li>',
     ]
-
-
-# TODO: check query is logged properly


### PR DESCRIPTION
This PR addresses issue [#313](https://github.com/yashaka/selene/issues/313) by refactoring multiple test files in the tests/integration directory. Specifically:

Replaced all model.* import usage with the updated selene.support.shared.browser and related APIs.

Reformatted tests to follow the Given / When / Then (GWT) structure for better readability and maintainability.

Cleaned up old TODO comments where applicable.

Verified all changes by running the full test suite locally with pytest.