### PR TITLE
Add example for hard-wait (sleep) before command

### DIFF
--- a/examples/test_hard_wait_example.py
+++ b/examples/test_hard_wait_example.py
@@ -1,0 +1,8 @@
+import time
+from selene.support.shared import browser
+from selene import have
+
+def test_example_with_hard_wait():
+    browser.open('https://example.com')
+    time.sleep(3)  # ⏱ Hard wait before command
+    browser.element('h1').should(have.text('Example Domain'))


### PR DESCRIPTION
This PR adds a simple test in the examples folder that demonstrates how to use a hard wait using time.sleep() before executing a browser command. It opens a page and asserts the header text.
