### PR TITLE
Fix broken Table of Contents links in README for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Selene’s core strength is its user-oriented API, which abstracts the complexit
 
 ## Table of Contents
 
-- [Main Features](#main-features)
-- [Versions](#versions)
-  - [Migration Guide](#migration-guide)
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Quick Start](#quick-start)
-  - [Core API](#core-api)
-  - [Advanced API](#advanced-api)
-- [Tutorials](#tutorials)
-- [Expanded Examples](#expanded-examples)
-- [Contribution](#contribution)
-- [Changelog](#changelog)
+- [Main Features](https://github.com/yashaka/selene#main-features)
+- [Versions](https://github.com/yashaka/selene#versions)
+  - [Migration Guide](https://github.com/yashaka/selene#migration-guide)
+- [Prerequisites](https://github.com/yashaka/selene#prerequisites)
+- [Installation](https://github.com/yashaka/selene#installation)
+- [Usage](https://github.com/yashaka/selene#usage)
+  - [Quick Start](https://github.com/yashaka/selene#quick-start)
+  - [Core API](https://github.com/yashaka/selene#core-api)
+  - [Advanced API](https://github.com/yashaka/selene#advanced-api)
+- [Tutorials](https://github.com/yashaka/selene#tutorials)
+- [Expanded Examples](https://github.com/yashaka/selene#expanded-examples)
+- [Contribution](https://github.com/yashaka/selene#contribution)
+- [Changelog](https://github.com/yashaka/selene#changelog)
 
 ## Main Features
 
@@ -71,7 +71,7 @@ Selene currently supports two major versions:
   - Selenium support: `<4.0.0`
   - Use this version if your project requires compatibility with older Python versions.
   
-For migration from v1.x to v2.x, follow the [migration guide](#migration-guide).
+For migration from v1.x to v2.x, follow the [migration guide](https://github.com/yashaka/selene#migration-guide).
 
 ### Migration Guide
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Selene’s core strength is its user-oriented API, which abstracts the complexit
 - [Usage](https://github.com/yashaka/selene#usage)
   - [Quick Start](https://github.com/yashaka/selene#quick-start)
   - [Core API](https://github.com/yashaka/selene#core-api)
+  - [Automatic Driver and Browser Management](https://github.com/yashaka/selene#automatic-driver-and-browser-management)
   - [Advanced API](https://github.com/yashaka/selene#advanced-api)
 - [Tutorials](https://github.com/yashaka/selene#tutorials)
-- [Expanded Examples](https://github.com/yashaka/selene#Examples)
+- [Examples](https://github.com/yashaka/selene#Examples)
 - [Contribution](https://github.com/yashaka/selene#contribution)
+- [Release Workflow](https://github.com/yashaka/selene#release-workflow)
 - [Changelog](https://github.com/yashaka/selene#changelog)
 
 ## Main Features

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Selene’s core strength is its user-oriented API, which abstracts the complexit
   - [Core API](https://github.com/yashaka/selene#core-api)
   - [Advanced API](https://github.com/yashaka/selene#advanced-api)
 - [Tutorials](https://github.com/yashaka/selene#tutorials)
-- [Expanded Examples](https://github.com/yashaka/selene#expanded-examples)
+- [Expanded Examples](https://github.com/yashaka/selene#Examples)
 - [Contribution](https://github.com/yashaka/selene#contribution)
 - [Changelog](https://github.com/yashaka/selene#changelog)
 


### PR DESCRIPTION
This PR updates the README Table of Contents so that navigation works properly on PyPI:

- Fixed links for "Advanced API" and "Expanded Examples" by replacing relative anchors with absolute GitHub URLs.
- Synced TOC structure with the latest README (added "Automatic Driver and Browser Management", "Examples", and "Release Workflow").and Ensures that all sections (e.g., Advanced API, Tutorials, Examples) link correctly 
to their respective headings, improving navigation and readability.

Closes #493.

Hope this helps improve the project. Please let me know if you’d like me to adjust anything.
