### PR TITLE
NEW: Add get_text and get_attribute methods to Element class

### DIFF
--- a/selene/web/_elements.py
+++ b/selene/web/_elements.py
@@ -820,6 +820,26 @@ class Element(_LocatableEntity[WebElement], _WaitingConfiguredEntity):
         )
 
         return self
+     
+    def get_text(self) -> str:
+        """Gets the text content of the element.
+
+        See more at [query.text][selene.core.query.text].
+        """
+
+        from selene.core import query
+
+        return self.get(query.text)
+    
+    def get_attribute(self, name: str) -> Optional[str]:
+        """Gets the value of the specified attribute of the element.
+
+        See more at [query.attribute][selene.core.query.attribute].
+        """
+
+        from selene.core import query
+
+        return self.get(query.attribute(name))
 
 
 # TODO: consider renaming or at list aliased to AllElements


### PR DESCRIPTION
## Description

This PR adds two new convenience methods to the `Element` class in `selene/web/_elements.py`:

- `get_text()` - Returns the text content of the element
- `get_attribute(name)` - Returns the value of the specified attribute of the element

## Added Methods

```python
def get_text(self) -> str:
    """Gets the text content of the element."""
    from selene.core import query
    return self.get(query.text)

def get_attribute(self, name: str) -> Optional[str]:
    """Gets the value of the specified attribute of the element."""
    from selene.core import query
    return self.get(query.attribute(name))
```

## Usage Examples

```python
# Before
text = browser.element('#my-element').get(query.text)
href = browser.element('a').get(query.attribute('href'))

# After
text = browser.element('#my-element').get_text()
href = browser.element('a').get_attribute('href')
```

## Benefits

- **More intuitive API**: Simpler and more readable syntax
- **Backward compatible**: No breaking changes
- **Familiar**: Similar to Selenium WebElement methods
- **Consistent**: Leverages existing query functionality

## Implementation

Both methods use existing `query.text` and `query.attribute` functionality, so no additional tests are required.

## Commit Message
```
[#ISSUE_NUMBER] NEW: Add get_text and get_attribute methods to Element class

Add convenience methods get_text() and get_attribute(name) to Element class
for more intuitive API compared to element.get(query.text/attribute).
```