### PR TITLE
Add hard-wait (sleep) example before waiting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ browser.all('#rso>div').should(have.size_greater_than(5))\
 # not mandatory, because will be closed automatically:
 # browser.quit()
 ```
+## Tutorials
+
+- Selene: Quick Start
+- Selene in action
+- Selene for PageObjects
+- **Hard Wait Example:** [examples/waits/hard_wait_then_wait_example.py](examples/waits/hard_wait_then_wait_example.py) – demonstrates why explicit waits are preferred over hardcoded sleeps in UI testing.
+
 
 ### Core API
 

--- a/examples/waits/hard_wait_then_wait_example.py
+++ b/examples/waits/hard_wait_then_wait_example.py
@@ -1,0 +1,26 @@
+"""
+Example: Hard Wait (sleep) before waiting command in Selene
+
+WARNING: Using time.sleep() is generally discouraged. It can make tests flaky or unnecessarily slow. 
+Use Selene's explicit waits whenever possible, and only use sleep for debugging or rare edge cases.
+
+To run:
+    python examples/waits/hard_wait_then_wait_example.py
+Requires: selene, selenium, webdriver-manager
+"""
+import time
+from selene.support.shared import browser
+from selene import be
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+
+browser.config.driver_name = 'chrome'
+browser.config.driver = Service(ChromeDriverManager().install())
+browser.open('https://example.com')
+
+time.sleep(2)
+browser.element('h1').should(be.visible)
+
+browser.element('h1').should(be.visible)
+
+browser.quit()


### PR DESCRIPTION
Adds an example demonstrating when a hard wait (time.sleep) might be used, 
while recommending explicit waits as best practice.

Changes:
- Added: examples/waits/hard_wait_then_wait_example.py
- Updated: README.md with link to example

References Selenium waiting best practices: https://selenium.dev/documentation/webdriver/waits/
