### PR TITLE
Fix ImportError with Selenium 4.40+: Replace AnyDevice import

### DIFF
--- a/selene/core/_actions.py
+++ b/selene/core/_actions.py
@@ -27,7 +27,12 @@ from selenium.webdriver.common.actions.wheel_input import ScrollOrigin
 from selenium.webdriver.remote.webelement import WebElement
 
 from selenium.webdriver import ActionChains
-from selenium.webdriver.common.action_chains import AnyDevice
+from selenium.webdriver.common.actions.pointer_input import PointerInput
+from selenium.webdriver.common.actions.key_input import KeyInput
+from selenium.webdriver.common.actions.wheel_input import WheelInput
+
+# AnyDevice type alias for compatibility with Selenium 4.40+
+AnyDevice = Union[PointerInput, KeyInput, WheelInput]
 
 from selene.core._element import Element
 from selene.core.configuration import Config


### PR DESCRIPTION
- Replace direct import of AnyDevice from action_chains
- Define AnyDevice as Union type alias locally
- Fixes #596: ImportError with Selenium 4.43.0
- Fixes #595: Incompatible with Selenium v.4.40.0

The AnyDevice type was removed from selenium.webdriver.common.action_chains in Selenium 4.40+. This patch defines it locally as a type alias to maintain backward compatibility.

Tested with:
- Selenium 4.43.0
- Python 3.12
- All existing tests pass