### PR TITLE
CI: split PR test pipeline by pytest markers (regression/clipboard/speed/remote)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: tests
 
 on:
-
   push:
     paths-ignore:
       - .run/
@@ -19,7 +18,6 @@ on:
       - .github/workflows/publish.yml
       - .github/workflows/traffic2badge.yml
       - .github/FUNDING.yml
-
   pull_request:
     paths-ignore:
       - .run/
@@ -39,67 +37,110 @@ on:
       - .github/FUNDING.yml
 
 jobs:
-
-  test:
+  regression:
+    name: Regression (blocking)
     runs-on: ubuntu-latest
     env:
       DISPLAY: ":99"
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      selenoid_login: ${{ secrets.SELENOID_LOGIN }}
-      selenoid_password: ${{ secrets.SELENOID_PASSWORD }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ '3.10' ]
-#        python-version: [ '3.10', '3.14' ]
-
     steps:
       - uses: actions/checkout@v5
-
-      - uses: tj-actions/changed-files@v44
-        id: changed-files
+      - uses: actions/setup-python@v6
         with:
-          files: |
-            poetry.lock
-            **/tests.yml
-            {selene,tests}/**/*.py
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-        if: steps.changed-files.outputs.any_modified == 'true'
-
-      # can be packaged as Docker-image
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
-        if: steps.changed-files.outputs.any_modified == 'true'
-
-      # can be packaged as Docker-image; p.s.: no need to install chrome or firefox on github-actions
       - name: Install xvfb
         run: |
           sudo apt-get update
-          sudo apt-get install xvfb
+          sudo apt-get install -y xvfb
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-        if: steps.changed-files.outputs.any_modified == 'true'
-
-      - name: Install a copy/paste mechanism
+      - name: Regression tests
         run: |
-          sudo apt-get install xclip
-        if: steps.changed-files.outputs.any_modified == 'true'
-
-      - name: Tests
-        run: |
-          poetry run pytest -sv --cov-config .coveragerc --cov-report html:skip-covered --cov-report term:skip-covered --cov=selene  --cov-report xml:coverage.xml --tb=short tests/ --headless=True
-          mkdir -p Artifacts/skip-covered
-          cp -r skip-covered Artifacts/skip-covered
-        if: steps.changed-files.outputs.any_modified == 'true'
-
+          poetry run pytest -sv \
+            --cov-config .coveragerc \
+            --cov-report html:skip-covered \
+            --cov-report term:skip-covered \
+            --cov=selene \
+            --cov-report xml:coverage.xml \
+            --tb=short \
+            -m "not (clipboard or speed or remote or flaky)" \
+            tests/ \
+            --headless=True
       - name: Code Coverage
         uses: codecov/codecov-action@v4.5.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: steps.changed-files.outputs.any_modified == 'true'
+
+  clipboard:
+    name: Clipboard (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      DISPLAY: ":99"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Install xvfb and xclip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb xclip
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+      - name: Clipboard tests
+        run: poetry run pytest -sv --tb=short -m "clipboard" tests/ --headless=True
+
+  speed:
+    name: Speed (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      DISPLAY: ":99"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Install xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+      - name: Speed tests
+        run: poetry run pytest -sv --tb=short -m "speed" tests/ --headless=True
+
+  remote:
+    name: Remote (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ secrets.SELENOID_LOGIN != '' && secrets.SELENOID_PASSWORD != '' }}
+    env:
+      DISPLAY: ":99"
+      selenoid_login: ${{ secrets.SELENOID_LOGIN }}
+      selenoid_password: ${{ secrets.SELENOID_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Remote tests
+        run: poetry run pytest -sv --tb=short -m "remote" tests/ --headless=True

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,40 +1,21 @@
 name: tests
 
 on:
+  workflow_dispatch:
   push:
-    paths-ignore:
-      - .run/
-      - examples/
-      - .coveragerc
-      - .gitignore
-      - .pylint-disabled-rules
-      - CHANGELOG.md
-      - CONTRIBUTING.md
-      - LICENSE
-      - mkdocs.yml
-      - README.md
-      - .github/workflows/deploy-mkdocs-poetry.yml
-      - .github/workflows/linters.yml
-      - .github/workflows/publish.yml
-      - .github/workflows/traffic2badge.yml
-      - .github/FUNDING.yml
+    paths:
+      - "selene/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - ".github/workflows/tests.yml"
   pull_request:
-    paths-ignore:
-      - .run/
-      - examples/
-      - .coveragerc
-      - .gitignore
-      - .pylint-disabled-rules
-      - CHANGELOG.md
-      - CONTRIBUTING.md
-      - LICENSE
-      - mkdocs.yml
-      - README.md
-      - .github/workflows/deploy-mkdocs-poetry.yml
-      - .github/workflows/linters.yml
-      - .github/workflows/publish.yml
-      - .github/workflows/traffic2badge.yml
-      - .github/FUNDING.yml
+    paths:
+      - "selene/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - ".github/workflows/tests.yml"
 
 jobs:
   regression:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,20 +108,32 @@ jobs:
     name: Remote (non-blocking)
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: ${{ secrets.SELENOID_LOGIN != '' && secrets.SELENOID_PASSWORD != '' }}
     env:
       DISPLAY: ":99"
       selenoid_login: ${{ secrets.SELENOID_LOGIN }}
       selenoid_password: ${{ secrets.SELENOID_PASSWORD }}
     steps:
+      - name: Check remote credentials
+        id: check_remote
+        run: |
+          if [ -n "${selenoid_login}" ] && [ -n "${selenoid_password}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Remote tests are skipped: SELENOID credentials are missing."
+          fi
       - uses: actions/checkout@v5
+        if: steps.check_remote.outputs.enabled == 'true'
       - uses: actions/setup-python@v6
+        if: steps.check_remote.outputs.enabled == 'true'
         with:
           python-version: "3.10"
       - name: Install dependencies
+        if: steps.check_remote.outputs.enabled == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
       - name: Remote tests
+        if: steps.check_remote.outputs.enabled == 'true'
         run: poetry run pytest -sv --tb=short -m "remote" tests/ --headless=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
+addopts = "--color=yes"
 markers = [
     "smoke: critical fast checks",
     "regression: stable functional regression",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,16 @@ exclude = [
     '^.+_test\.py$',
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "smoke: critical fast checks",
+    "regression: stable functional regression",
+    "clipboard: OS/shortcut-dependent clipboard tests",
+    "speed: performance-sensitive comparisons",
+    "remote: requires remote webdriver + secrets",
+    "flaky: known unstable tests (non-blocking)",
+]
+
 
 [tool.black]
 line-length = 88

--- a/tests/acceptance/speed_comparison_of_simple_element_actions_test.py
+++ b/tests/acceptance/speed_comparison_of_simple_element_actions_test.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import pytest
 from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -31,6 +32,8 @@ from selene.support.shared import browser
 from tests import resources
 from tests.acceptance.helpers.helper import get_test_driver
 from tests.helpers import time_spent
+
+pytestmark = [pytest.mark.speed, pytest.mark.flaky]
 
 TODOMVC_URL = resources.TODOMVC_URL
 

--- a/tests/integration/browser__switch_to__alert__remote_test.py
+++ b/tests/integration/browser__switch_to__alert__remote_test.py
@@ -24,6 +24,8 @@ from selenium.common.exceptions import NoAlertPresentException
 
 from tests.integration.helpers.givenpage import GivenPage
 
+pytestmark = [pytest.mark.remote, pytest.mark.flaky]
+
 
 @pytest.fixture(scope='function')
 def with_dismiss_alerts_teardown(the_module_remote_browser):

--- a/tests/integration/command__copy__paste_test.py
+++ b/tests/integration/command__copy__paste_test.py
@@ -7,6 +7,8 @@ from selene import have, command
 import pyperclip
 from tests.integration.helpers.givenpage import GivenPage
 
+pytestmark = [pytest.mark.clipboard, pytest.mark.flaky]
+
 
 def test_copy_currently_selected_text_on_the_page_into_clipboard_via_shortcut(
     session_browser,

--- a/tests/integration/command__copy__paste_test.py
+++ b/tests/integration/command__copy__paste_test.py
@@ -3,6 +3,7 @@ Reflects main scenarios from docs/faq/clipboard-copy-and-paste-howto.md
 (those that uses either command.copy or command.paste explicitly or implicitly)
 """
 
+import pytest
 from selene import have, command
 import pyperclip
 from tests.integration.helpers.givenpage import GivenPage


### PR DESCRIPTION
## Summary
Split PR test execution into stable blocking regression and non-blocking quality suites using pytest markers.

## What changed
- Added pytest markers in `pyproject.toml`:
  - `smoke`, `regression`, `clipboard`, `speed`, `remote`, `flaky`
- Marked test modules:
  - `tests/integration/command__copy__paste_test.py` -> `clipboard`, `flaky`
  - `tests/acceptance/speed_comparison_of_simple_element_actions_test.py` -> `speed`, `flaky`
  - `tests/integration/browser__switch_to__alert__remote_test.py` -> `remote`, `flaky`
- Reworked `.github/workflows/tests.yml` into 4 jobs:
  - `regression` (blocking): `-m "not (clipboard or speed or remote or flaky)"`
  - `clipboard` (non-blocking)
  - `speed` (non-blocking)
  - `remote` (non-blocking, runs only when remote secrets are present)

## Why
PR gate should stay stable and fast, while still collecting signal from environment-sensitive suites:
- clipboard shortcuts are OS/focus dependent
- speed assertions are host-noise sensitive
- remote tests depend on external auth/infrastructure

## Validation
- local marker discovery: `pytest --markers`
- clipboard suite on current branch: `9 passed`
