### PR TITLE
CHORE: harden publish workflow: remove bump/commit; check tag vs pyproject and __version__

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -42,7 +42,11 @@ jobs:
         with:
           python-version: '3.10'
       - run: |
-          pip install black==24.2.0
+          pip install tomli
+          # Keep CI in sync with local Poetry env:
+          # read black version from poetry.lock and install only that package via pip.
+          BLACK_VERSION=$(python .run/get_lock_version.py black)
+          pip install "black==$BLACK_VERSION"
           .run/lint_black.sh
 
   Pycodestyle:
@@ -55,7 +59,9 @@ jobs:
           python-version: '3.10'
       - name: Pycodestyle
         run: |
-          pip install pycodestyle
+          pip install tomli
+          PYCODESTYLE_VERSION=$(python .run/get_lock_version.py pycodestyle)
+          pip install "pycodestyle==$PYCODESTYLE_VERSION"
           .run/lint_pycodestyle.sh
 
   Pylint:
@@ -68,7 +74,9 @@ jobs:
           python-version: '3.10'
       - name: Pylint
         run: |
-          pip install pylint
+          pip install tomli
+          PYLINT_VERSION=$(python .run/get_lock_version.py pylint)
+          pip install "pylint==$PYLINT_VERSION"
           .run/lint_pylint.sh
 
   Pylint-full-report:
@@ -81,7 +89,9 @@ jobs:
           python-version: '3.10'
       - name: Pylint Full Report
         run: |
-          pip install pylint
+          pip install tomli
+          PYLINT_VERSION=$(python .run/get_lock_version.py pylint)
+          pip install "pylint==$PYLINT_VERSION"
           touch __init__.py
           pylint $(pwd) --disable="" --ignore-patterns=.venv --exit-zero
           rm __init__.py
@@ -96,5 +106,9 @@ jobs:
           python-version: '3.10'
       - name: Mypy
         run: |
-          pip install mypy
+          pip install tomli
+          # Keep CI in sync with local Poetry env:
+          # read mypy version from poetry.lock and install only that package via pip.
+          MYPY_VERSION=$(python .run/get_lock_version.py mypy)
+          pip install "mypy==$MYPY_VERSION"
           .run/lint_mypy.sh

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -48,6 +50,8 @@ jobs:
           BLACK_VERSION=$(python .run/get_lock_version.py black)
           pip install "black==$BLACK_VERSION"
           .run/lint_black.sh
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
 
   Pycodestyle:
     name: Lint Pycodestyle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Publish Python Package
 on:
   release:
     types: [published]
@@ -8,22 +8,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
       - uses: abatilo/actions-poetry@v4
 
-      - name: Bump version
+      - name: Install twine
+        run: pip install twine
+
+      - name: Release context
         run: |
-          version=${{ github.event.release.tag_name }}
-          poetry version $version
-          sed -i "s/__version__ = .*/__version__ = \'${version}\'/g" ./selene/__init__.py
+          echo "release.tag_name=${{ github.event.release.tag_name }}"
+          echo "release.target_commitish=${{ github.event.release.target_commitish }}"
+          echo "github.ref=${GITHUB_REF}"
+          echo "github.ref_name=${GITHUB_REF_NAME}"
+          echo "github.sha=${GITHUB_SHA}"
 
-      - name: Commit version
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: '["pyproject.toml", "selene/__init__.py"]'
-          branch: "master" # TODO: is it correct?
-          message: "bump version up to ${{ github.event.release.tag_name }}"
+      - name: Check release version consistency
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+        run: python .run/check_release_version.py
 
-      - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v2.1
-        with:
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
+      - name: Build
+        run: poetry build
+
+      - name: Check dist
+        run: twine check dist/*
+
+      - name: Publish
+        run: poetry publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"

--- a/.run/check_release_version.py
+++ b/.run/check_release_version.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import tomllib
+
+
+def _read_pyproject_version(pyproject_path: Path) -> str:
+    data = tomllib.loads(pyproject_path.read_text())
+
+    project = data.get("project", {})
+    version = project.get("version")
+    if version:
+        return version
+
+    poetry = data.get("tool", {}).get("poetry", {})
+    version = poetry.get("version")
+    if version:
+        return version
+
+    raise RuntimeError(
+        "Version is not found in pyproject.toml (project.version or tool.poetry.version)"
+    )
+
+
+def _read_init_version(init_path: Path) -> str:
+    content = init_path.read_text()
+    match = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", content, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"__version__ is not found in {init_path}")
+    return match.group(1)
+
+
+def _git_branch() -> str:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "branch", "--show-current"], text=True
+            ).strip()
+            or "<detached>"
+        )
+    except Exception:
+        return "<unknown>"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check release tag consistency with pyproject.toml and selene/__init__.py"
+    )
+    parser.add_argument(
+        "--tag", default=os.getenv("RELEASE_TAG") or os.getenv("GITHUB_REF_NAME")
+    )
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument("--init", default="selene/__init__.py")
+    args = parser.parse_args()
+
+    if not args.tag:
+        print(
+            "ERROR: release tag is not provided. Pass --tag or set RELEASE_TAG/GITHUB_REF_NAME.",
+            file=sys.stderr,
+        )
+        return 2
+
+    tag = args.tag
+    pyproject_version = _read_pyproject_version(Path(args.pyproject))
+    init_version = _read_init_version(Path(args.init))
+
+    context = {
+        "release_tag": tag,
+        "release_target_commitish": os.getenv("RELEASE_TARGET_COMMITISH", "<unknown>"),
+        "github_ref": os.getenv("GITHUB_REF", "<unknown>"),
+        "github_ref_name": os.getenv("GITHUB_REF_NAME", "<unknown>"),
+        "github_sha": os.getenv("GITHUB_SHA", "<unknown>"),
+        "git_branch": _git_branch(),
+    }
+
+    print("Release check context:")
+    for key, value in context.items():
+        print(f"- {key}: {value}")
+
+    errors: list[str] = []
+    if pyproject_version != tag:
+        errors.append(
+            f"pyproject version mismatch: expected '{tag}', got '{pyproject_version}' ({args.pyproject})"
+        )
+    if init_version != tag:
+        errors.append(
+            f"__version__ mismatch: expected '{tag}', got '{init_version}' ({args.init})"
+        )
+
+    if errors:
+        print("\nRelease version check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print(
+            "\nAction required: fix versions in source branch before creating/publishing release tag.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nRelease version check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.run/get_lock_version.py
+++ b/.run/get_lock_version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover - CI on Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: get_lock_version.py <package-name>", file=sys.stderr)
+        return 2
+
+    package_name = sys.argv[1]
+    lock_path = Path("poetry.lock")
+    if not lock_path.exists():
+        print("poetry.lock not found", file=sys.stderr)
+        return 1
+
+    data: dict[str, Any] = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    for package in data.get("package", []):
+        if package.get("name") == package_name:
+            print(package["version"])
+            return 0
+
+    print(f"Package not found in poetry.lock: {package_name}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.run/lint_black.sh
+++ b/.run/lint_black.sh
@@ -1,2 +1,41 @@
 #!/bin/bash
-black . --check --diff
+set -euo pipefail
+
+run_black_on_all() {
+  echo "Running black on all files (fallback mode)"
+  black . --check --diff
+}
+
+get_changed_python_files() {
+  local diff_base="${1:-}"
+  if [[ -z "$diff_base" ]]; then
+    return 0
+  fi
+
+  git diff --name-only --diff-filter=ACMR "${diff_base}...HEAD" -- '*.py'
+}
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+  BASE_COMMIT="$(git merge-base HEAD FETCH_HEAD || true)"
+elif [[ "${GITHUB_EVENT_NAME:-}" == "push" && -n "${GITHUB_EVENT_BEFORE:-}" ]]; then
+  BASE_COMMIT="${GITHUB_EVENT_BEFORE}"
+else
+  BASE_COMMIT=""
+fi
+
+if [[ -z "${BASE_COMMIT}" ]]; then
+  run_black_on_all
+  exit 0
+fi
+
+mapfile -t CHANGED_PYTHON_FILES < <(get_changed_python_files "${BASE_COMMIT}")
+
+if [[ "${#CHANGED_PYTHON_FILES[@]}" -eq 0 ]]; then
+  echo "No changed Python files in diff, skipping black"
+  exit 0
+fi
+
+echo "Running black on changed files:"
+printf '%s\n' "${CHANGED_PYTHON_FILES[@]}"
+black --check --diff "${CHANGED_PYTHON_FILES[@]}"


### PR DESCRIPTION
This PR makes release publishing deterministic and safe by removing all source mutations from publish job.

### What changed
1. Reworked [`publish.yml`](https://github.com/yashaka/selene/blob/master/.github/workflows/publish.yml) to follow `verify -> build -> publish`.
2. Removed release-time version mutation:
- removed `poetry version ...`
- removed `sed` update of `selene/__init__.py`
- removed commit-back step (`EndBug/add-and-commit`)
3. Added explicit release context logging in CI:
- `release.tag_name`
- `release.target_commitish`
- `GITHUB_REF`, `GITHUB_REF_NAME`, `GITHUB_SHA`
4. Added reusable checker script: [`.run/check_release_version.py`](https://github.com/yashaka/selene/blob/master/.run/check_release_version.py)
- validates `tag == pyproject version`
- validates `tag == selene.__version__`
- fails with actionable error message when mismatched

### Why
Previous publish flow could commit into `master` during release and mutate sources at publish time, which creates risks:
1. Release from `2.x/rc` branch could still write to `master`.
2. Published artifact might diverge from tagged commit.
3. Empty/unpredictable commit behavior when version already matched.
4. Release pipeline should publish artifacts, not rewrite repository state.

### New release model
1. Tag points to already-correct source commit.
2. Publish workflow does not bump or commit anything.
3. Workflow only verifies consistency, builds, checks, and publishes.

### Local preflight
```bash
python3 .run/check_release_version.py --tag <release-tag>
```