### PR TITLE
FIX #567: support _assert_location_changed in js drag_and_drop_to 2.0.0rc9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ TODOs:
   `error`) to keep error messages backward-compatible across Python versions
 - fixed `query.attribute(...)` typing to reflect that Selenium can return
   `None` for missing attributes
+- fixed ignored `_assert_location_changed` in `command.js.drag_and_drop_to` (#567).
 
 ### Changed
 

--- a/selene/core/command.py
+++ b/selene/core/command.py
@@ -389,61 +389,81 @@ class js:  # pylint: disable=invalid-name
     # TODO: add js.drag_and_drop_by_offset(x, y)
 
     @staticmethod
-    def drag_and_drop_to(target: Element) -> Command[Element]:
-        """
-        Simulates drag and drop via JavaScript.
+    def drag_and_drop_to(
+        target: Element,
+        _assert_location_changed: bool = False,
+    ) -> Command[Element]:
+        """Simulates drag and drop via JavaScript.
+
+        Args:
+            target: a destination element to drag and drop to
+            _assert_location_changed: False by default, but if True, then will
+                assert that element was dragged to the new location, hence forcing
+                a command retry if command was under waiting.
 
         May not work everywhere. Among known cases:
         * does not work on https://mui.com/material-ui/react-slider/#ContinuousSlider
           where the normal drag and drop works fine.
         """
 
-        def func(source: Element):
+        def func(source: Element) -> None:
+            source_webelement = source.locate()
+            source_location = (
+                source_webelement.location if _assert_location_changed else None
+            )
+
             script = """
             (function() {
-              function createEvent(typeOfEvent) {
-                var event = document.createEvent('CustomEvent');
-                event.initCustomEvent(typeOfEvent, true, true, null);
-                event.dataTransfer = {
-                  data: {},
-                  setData: function(key, value) {
-                    this.data[key] = value;
-                  },
-                  getData: function(key) {
-                    return this.data[key];
-                  }
-                };
-                return event;
-              }
-
-              function dispatchEvent(element, event, transferData) {
-                if (transferData !== undefined) {
-                  event.dataTransfer = transferData;
+                function createEvent(typeOfEvent) {
+                    var event = document.createEvent('CustomEvent');
+                    event.initCustomEvent(typeOfEvent, true, true, null);
+                    event.dataTransfer = {
+                        data: {},
+                        setData: function(key, value) {
+                            this.data[key] = value;
+                        },
+                        getData: function(key) {
+                            return this.data[key];
+                        }
+                    };
+                    return event;
                 }
-                if (element.dispatchEvent) {
-                  element.dispatchEvent(event);
-                } else if (element.fireEvent) {
-                  element.fireEvent("on" + event.type, event);
+
+                function dispatchEvent(element, event, transferData) {
+                    if (transferData !== undefined) {
+                        event.dataTransfer = transferData;
+                    }
+
+                    if (element.dispatchEvent) {
+                        element.dispatchEvent(event);
+                    } else if (element.fireEvent) {
+                        element.fireEvent("on" + event.type, event);
+                    }
                 }
-              }
 
-              function dragAndDrop(element, target) {
-                var dragStartEvent = createEvent('dragstart');
-                dispatchEvent(element, dragStartEvent);
-                var dropEvent = createEvent('drop');
-                dispatchEvent(target, dropEvent, dragStartEvent.dataTransfer);
-                var dragEndEvent = createEvent('dragend');
-                dispatchEvent(element, dragEndEvent, dropEvent.dataTransfer);
-              }
+                function dragAndDrop(element, target) {
+                    var dragStartEvent = createEvent('dragstart');
+                    dispatchEvent(element, dragStartEvent);
 
-              return dragAndDrop(arguments[0], arguments[1]);
+                    var dropEvent = createEvent('drop');
+                    dispatchEvent(target, dropEvent, dragStartEvent.dataTransfer);
+
+                    var dragEndEvent = createEvent('dragend');
+                    dispatchEvent(element, dragEndEvent, dropEvent.dataTransfer);
+                }
+
+                return dragAndDrop(arguments[0], arguments[1]);
             })(...arguments)
             """.strip()
+
             source.config.driver.execute_script(
                 script,
-                source.locate(),
+                source_webelement,
                 target.locate(),
             )
+
+            if _assert_location_changed and source_location == source.locate().location:
+                raise _SeleneError('Element was not dragged to the new place')
 
         return Command(f'drag and drop to: {target}', func)
 

--- a/tests/integration/element__perform__js__drag_and_drop_to_test.py
+++ b/tests/integration/element__perform__js__drag_and_drop_to_test.py
@@ -1,7 +1,10 @@
+import pytest
+
 from typing import Optional
 
 import selene
 from selene import command, be, have, query
+from selene.core.exceptions import TimeoutException
 from tests.integration.helpers.givenpage import GivenPage
 
 
@@ -9,8 +12,7 @@ def test_js_drags_source_and_drops_it_to_target(session_browser):
     browser = session_browser.with_(timeout=0.5)
     page = GivenPage(browser.driver)
     page.opened_empty()
-    page.add_style_to_head(
-        """
+    page.add_style_to_head("""
         #target1, #target2 {
           float: left;
           width: 100px;
@@ -19,10 +21,8 @@ def test_js_drags_source_and_drops_it_to_target(session_browser):
           padding: 10px;
           border: 1px solid black;
         }
-        """
-    )
-    page.add_script_to_head(
-        """
+    """)
+    page.add_script_to_head("""
         function allowDrop(ev) {
           ev.preventDefault();
         }
@@ -36,10 +36,8 @@ def test_js_drags_source_and_drops_it_to_target(session_browser):
           var data = ev.dataTransfer.getData('text');
           ev.target.appendChild(document.getElementById(data));
         }
-        """
-    )
-    page.load_body(
-        '''
+    """)
+    page.load_body("""
         <h2>Drag and Drop</h2>
         <p>Drag the image back and forth between the two div elements.</p>
 
@@ -54,8 +52,7 @@ def test_js_drags_source_and_drops_it_to_target(session_browser):
         </div>
 
         <div id="target2" ondrop="drop(event)" ondragover="allowDrop(event)"></div>
-        '''
-    )
+    """)
 
     # WHEN
     browser.element('#draggable').perform(
@@ -100,3 +97,92 @@ def test_js_does_not_drag_react_mui_slider(session_browser):
 
     slider.thumb_input.should(have.value(original_value))
     slider.thumb_input.should(have.no.value('100'))
+
+
+def test_js_drag_and_drop_to_asserts_location_changed_when_requested(session_browser):
+    browser = session_browser.with_(timeout=0.5)
+    page = GivenPage(browser.driver)
+
+    page.opened_empty()
+    page.load_body("""
+        <div id="source" draggable="true">source</div>
+        <div id="target">target</div>
+
+        <script>
+            const source = document.querySelector('#source')
+            const target = document.querySelector('#target')
+
+            source.addEventListener('dragstart', event => {
+                event.dataTransfer.setData('text', event.target.id)
+            })
+
+            target.addEventListener('drop', event => {
+                event.preventDefault()
+                // intentionally do nothing:
+                // source location should remain unchanged
+            })
+        </script>
+    """)
+
+    with pytest.raises(TimeoutException):
+        browser.element('#source').perform(
+            command.js.drag_and_drop_to(
+                browser.element('#target'),
+                _assert_location_changed=True,
+            )
+        )
+
+
+def test_js_drag_and_drop_to_passes_when_location_changed(session_browser):
+    browser = session_browser.with_(timeout=0.5)
+    page = GivenPage(browser.driver)
+
+    page.opened_empty()
+    page.add_style_to_head("""
+        #target1, #target2 {
+            float: left;
+            width: 100px;
+            height: 35px;
+            margin: 10px;
+            padding: 10px;
+            border: 1px solid black;
+        }
+    """)
+    page.add_script_to_head("""
+        function allowDrop(ev) {
+            ev.preventDefault();
+        }
+
+        function drag(ev) {
+            ev.dataTransfer.setData('text', ev.target.id);
+        }
+
+        function drop(ev) {
+            ev.preventDefault();
+            var data = ev.dataTransfer.getData('text');
+            ev.target.appendChild(document.getElementById(data));
+        }
+    """)
+    page.load_body("""
+        <div id="target1" ondrop="drop(event)" ondragover="allowDrop(event)">
+            <img
+                id="draggable"
+                src="https://via.placeholder.com/20"
+                draggable="true"
+                ondragstart="drag(event)"
+            >
+        </div>
+
+        <div id="target2" ondrop="drop(event)" ondragover="allowDrop(event)">
+        </div>
+    """)
+
+    browser.element('#draggable').perform(
+        command.js.drag_and_drop_to(
+            browser.element('#target2'),
+            _assert_location_changed=True,
+        )
+    )
+
+    browser.element('#target1').element('#draggable').should(be.not_.present)
+    browser.element('#target2').element('#draggable').should(be.present)


### PR DESCRIPTION
## Summary

Fixes #567.

Adds `_assert_location_changed` support to:

```python
command.js.drag_and_drop_to(...)
```

to make JS drag-and-drop behavior consistent with regular
`command.drag_and_drop_to(...)`.

Before this change, `_assert_location_changed=True` was ignored
for JS-based drag and drop.

## Changes

* added `_assert_location_changed` argument to
  `command.js.drag_and_drop_to`
* added location-change assertion logic
* added integration tests for:

  * failing drag/drop when location does not change
  * successful drag/drop when location changes

## Result

Now JS drag-and-drop can participate correctly in Selene retry/wait
mechanism when element location is expected to change.
