### PR TITLE
Fix #486 `have.no.attribute(...).value_containing(...)` TypeError in 2.0.0rc9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ TODOs:
 - fixed `query.attribute(...)` typing to reflect that Selenium can return
   `None` for missing attributes
 - fixed ignored `_assert_location_changed` in `command.js.drag_and_drop_to` (#567).
+- fixed descriptor methods chained from negated conditions.
+  For example, `have.no.attribute(...).value_containing(...)` now works correctly. (#486)
 
 ### Changed
 

--- a/selene/support/conditions/not_.py
+++ b/selene/support/conditions/not_.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import warnings
+from types import MethodType
 from typing import Any
 
 from selene.core import match as _match
@@ -89,10 +90,10 @@ def attribute(name: str, *args, **kwargs):
     def values_containing(self, *expected: str) -> Condition[Collection]:
         return original.values_containing(*expected).not_
 
-    negated.value = value
-    negated.value_containing = value_containing
-    negated.values = values
-    negated.values_containing = values_containing
+    negated.value = MethodType(value, negated)
+    negated.value_containing = MethodType(value_containing, negated)
+    negated.values = MethodType(values, negated)
+    negated.values_containing = MethodType(values_containing, negated)
 
     return negated
 
@@ -125,10 +126,10 @@ def js_property(name: str, *args, **kwargs):
     def values_containing(self, *expected: str) -> Condition[Collection]:
         return original.values_containing(*expected).not_
 
-    negated.value = value
-    negated.value_containing = value_containing
-    negated.values = values
-    negated.values_containing = values_containing
+    negated.value = MethodType(value, negated)
+    negated.value_containing = MethodType(value_containing, negated)
+    negated.values = MethodType(values, negated)
+    negated.values_containing = MethodType(values_containing, negated)
 
     return negated
 
@@ -161,10 +162,10 @@ def css_property(name: str, *args, **kwargs):
     def values_containing(self, *expected: str) -> Condition[Collection]:
         return original.values_containing(*expected).not_
 
-    negated.value = value
-    negated.value_containing = value_containing
-    negated.values = values
-    negated.values_containing = values_containing
+    negated.value = MethodType(value, negated)
+    negated.value_containing = MethodType(value_containing, negated)
+    negated.values = MethodType(values, negated)
+    negated.values_containing = MethodType(values_containing, negated)
 
     return negated
 

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -9,11 +9,9 @@ def test_have_no_attribute_value_containing_does_not_raise_type_error(
 ):
     browser = session_browser.with_(timeout=0.1)
 
-    GivenPage(browser.driver).opened_with_body(
-        '''
+    GivenPage(browser.driver).opened_with_body('''
         <input id="firstname" class="name" value="John">
-        '''
-    )
+    ''')
 
     browser.element('.name').should(
         have.no.attribute('id').value_containing('last')
@@ -28,12 +26,10 @@ def test_have_no_attribute_value_containing_does_not_raise_type_error(
 def test_have_no_attribute_descriptor_methods_work(session_browser):
     browser = session_browser.with_(timeout=0.1)
 
-    GivenPage(browser.driver).opened_with_body(
-        '''
+    GivenPage(browser.driver).opened_with_body('''
         <input class="name" id="firstname" value="John">
-        <input class="name" id="lastname" value="Doe">
-        '''
-    )
+        <input class="name" id="lastname" value="Doe"> 
+    ''')
 
     name = browser.element('.name')
     names = browser.all('.name')

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -13,9 +13,7 @@ def test_have_no_attribute_value_containing_does_not_raise_type_error(
         <input id="firstname" class="name" value="John">
     ''')
 
-    browser.element('.name').should(
-        have.no.attribute('id').value_containing('last')
-    )
+    browser.element('.name').should(have.no.attribute('id').value_containing('last'))
 
     with pytest.raises(AssertionError):
         browser.element('.name').should(

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from selene import have
+from tests.integration.helpers.givenpage import GivenPage
+
+
+def test_have_no_attribute_value_containing_does_not_raise_type_error(
+    session_browser,
+):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body(
+        '''
+        <input id="firstname" class="name" value="John">
+        '''
+    )
+
+    browser.element('.name').should(
+        have.no.attribute('id').value_containing('last')
+    )
+
+    with pytest.raises(AssertionError):
+        browser.element('.name').should(
+            have.no.attribute('id').value_containing('first')
+        )
+
+
+def test_have_no_attribute_descriptor_methods_work(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body(
+        '''
+        <input class="name" id="firstname" value="John">
+        <input class="name" id="lastname" value="Doe">
+        '''
+    )
+
+    name = browser.element('.name')
+    names = browser.all('.name')
+
+    name.should(have.no.attribute('id').value('lastname'))
+    name.should(have.no.attribute('id').value_containing('last'))
+
+    names.should(have.no.attribute('id').values('foo', 'bar'))
+    names.should(have.no.attribute('id').values_containing('foo', 'bar'))
+
+    with pytest.raises(AssertionError):
+        name.should(have.no.attribute('id').value('firstname'))
+
+    with pytest.raises(AssertionError):
+        name.should(have.no.attribute('id').value_containing('first'))
+
+    with pytest.raises(AssertionError):
+        names.should(have.no.attribute('id').values('firstname', 'lastname'))
+
+    with pytest.raises(AssertionError):
+        names.should(have.no.attribute('id').values_containing('first', 'last'))

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -26,7 +26,7 @@ def test_have_no_attribute_descriptor_methods_work(session_browser):
 
     GivenPage(browser.driver).opened_with_body('''
         <input class="name" id="firstname" value="John">
-        <input class="name" id="lastname" value="Doe"> 
+        <input class="name" id="lastname" value="Doe">
     ''')
 
     name = browser.element('.name')

--- a/tests/integration/condition__elements__have_property_and_co_test.py
+++ b/tests/integration/condition__elements__have_property_and_co_test.py
@@ -1,0 +1,23 @@
+from selene import have
+from tests.integration.helpers.givenpage import GivenPage
+
+
+def test_have_no_js_property_and_css_property_descriptor_methods_work(
+    session_browser,
+):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body(
+        '''
+        <input id="field" value="John">
+        <div id="box" style="display: block">Box</div>
+        '''
+    )
+
+    browser.element('#field').should(
+        have.no.js_property('value').value_containing('Doe')
+    )
+
+    browser.element('#box').should(
+        have.no.css_property('display').value_containing('none')
+    )

--- a/tests/integration/condition__elements__have_property_and_co_test.py
+++ b/tests/integration/condition__elements__have_property_and_co_test.py
@@ -7,12 +7,10 @@ def test_have_no_js_property_and_css_property_descriptor_methods_work(
 ):
     browser = session_browser.with_(timeout=0.1)
 
-    GivenPage(browser.driver).opened_with_body(
-        '''
+    GivenPage(browser.driver).opened_with_body('''
         <input id="field" value="John">
         <div id="box" style="display: block">Box</div>
-        '''
-    )
+    ''')
 
     browser.element('#field').should(
         have.no.js_property('value').value_containing('Doe')


### PR DESCRIPTION
Fix #486 have.no.attribute(...).value_containing(...) TypeError in 2.0.0rc9+

The old implementation assigned nested functions directly to a condition instance.
Because instance-assigned functions are not automatically bound methods in Python,
calls like `have.no.attribute('id').value_containing('part')` missed the `expected`
argument.

Bind these dynamically attached descriptor methods via `types.MethodType`.
Apply the same fix to `attribute`, `js_property`, and `css_property`, since they
share the same implementation pattern.