### PR TITLE
#433 Fix collection.should with composed element conditions

### DIFF
--- a/selene/web/_elements.py
+++ b/selene/web/_elements.py
@@ -853,6 +853,31 @@ class Collection(_WaitingConfiguredEntity, Iterable[Element]):
     def __call__(self) -> typing.Sequence[WebElement]:
         return self.locate()
 
+    def should(
+        self,
+        condition: Union[Condition[Collection], Condition[Element]],
+    ) -> Collection:
+        def is_element_condition_applied_to_located_collection(
+            error: AttributeError,
+        ) -> bool:
+            return isinstance(
+                getattr(error, 'obj', None), list
+            ) or "'list' object has no attribute" in str(error)
+
+        def match(collection: Collection) -> None:
+            try:
+                condition(collection)  # type: ignore[arg-type]
+            except AttributeError as error:
+                if is_element_condition_applied_to_located_collection(error):
+                    Condition.for_each(condition)(collection)  # type: ignore[arg-type]
+                    return
+
+                raise
+
+        self.wait.for_(Condition(str(condition), match))
+
+        return self
+
     @property
     def cached(self) -> Collection:
         webelements = self.locate()

--- a/selene/web/_elements.py
+++ b/selene/web/_elements.py
@@ -857,29 +857,44 @@ class Collection(_WaitingConfiguredEntity, Iterable[Element]):
         self,
         condition: Union[Condition[Collection], Condition[Element]],
     ) -> Collection:
+        applied_as_each = False
+
         def is_element_condition_applied_to_located_collection(
-            error: AttributeError,
+            error: Exception,
         ) -> bool:
-            return isinstance(
-                getattr(error, 'obj', None), list
-            ) or "'list' object has no attribute" in str(error)
+            return (
+                isinstance(error, AttributeError)
+                and (
+                    isinstance(getattr(error, 'obj', None), list)
+                    or "'list' object has no attribute" in str(error)
+                )
+            ) or (
+                isinstance(error, AssertionError)
+                and "'list' object has no attribute" in str(error)
+            )
+
+        def name_for(collection: Collection | None = None) -> str:
+            return (
+                Condition.for_each(condition)._name_for(collection)
+                if applied_as_each
+                else condition._name_for(collection)  # type: ignore[arg-type]
+            )
 
         def match(collection: Collection) -> None:
+            nonlocal applied_as_each
+
             try:
                 condition(collection)  # type: ignore[arg-type]
-            except AttributeError as error:
+            except (AttributeError, AssertionError) as error:
                 if is_element_condition_applied_to_located_collection(error):
+                    applied_as_each = True
                     Condition.for_each(condition)(collection)  # type: ignore[arg-type]
                     return
 
                 raise
 
-        self.wait.for_(
-            Condition(
-                lambda entity: condition._name_for(entity),  # type: ignore[attr-defined]
-                match,
-            )
-        )
+        self.wait.for_(Condition(name_for, match))
+
         return self
 
     @property

--- a/selene/web/_elements.py
+++ b/selene/web/_elements.py
@@ -874,8 +874,12 @@ class Collection(_WaitingConfiguredEntity, Iterable[Element]):
 
                 raise
 
-        self.wait.for_(Condition(str(condition), match))
-
+        self.wait.for_(
+            Condition(
+                lambda entity: condition._name_for(entity),  # type: ignore[attr-defined]
+                match,
+            )
+        )
         return self
 
     @property

--- a/tests/integration/collection__should__element_condition_test.py
+++ b/tests/integration/collection__should__element_condition_test.py
@@ -1,0 +1,59 @@
+import pytest
+
+from selene import have
+from selene.core.exceptions import TimeoutException
+from tests.integration.helpers.givenpage import GivenPage
+
+
+def test_collection_should_accept_composed_element_condition(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <ul>
+            <li class="dropdown-list-item dropdown-list-item-disabled"
+                aria-disabled="true">First</li>
+            <li class="dropdown-list-item dropdown-list-item-disabled"
+                aria-disabled="true">Second</li>
+            <li class="dropdown-list-item dropdown-list-item-disabled"
+                aria-disabled="true">Third</li>
+        </ul>
+        ''')
+
+    browser.all('.dropdown-list-item').should(
+        have.css_class('dropdown-list-item-disabled').and_(
+            have.attribute('aria-disabled').value('true')
+        )
+    )
+
+
+def test_collection_should_report_per_element_mismatch_for_composed_element_condition(
+    session_browser,
+):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <ul>
+            <li class="dropdown-list-item dropdown-list-item-disabled"
+                aria-disabled="true">First</li>
+            <li class="dropdown-list-item"
+                aria-disabled="false">Second</li>
+            <li class="dropdown-list-item dropdown-list-item-disabled"
+                aria-disabled="true">Third</li>
+        </ul>
+        ''')
+
+    try:
+        browser.all('.dropdown-list-item').should(
+            have.css_class('dropdown-list-item-disabled').and_(
+                have.attribute('aria-disabled').value('true')
+            )
+        )
+
+        pytest.fail('should have failed on element condition mismatch')
+
+    except TimeoutException as error:
+        message = str(error)
+
+        assert 'Not matched elements among all' in message
+        assert ".cached[1]" in message
+        assert "'list' object has no attribute 'get_attribute'" not in message

--- a/tests/integration/collection__should__keeps_condition_name_test.py
+++ b/tests/integration/collection__should__keeps_condition_name_test.py
@@ -26,32 +26,3 @@ def test_collection_should_keeps_entity_aware_condition_name(session_browser):
 
         assert "browser.all(('css selector', 'li')).have size 2" in message
         assert "browser.all(('css selector', 'li')).has size 2" not in message
-
-
-def test_collection_should_keeps_ignore_case_condition_name(session_browser):
-    browser = session_browser.with_(timeout=0.1)
-
-    GivenPage(browser.driver).opened_with_body('''
-        <ul>
-            <li>1) One!!!</li>
-            <li>2) Two...</li>
-            <li>3) Three???</li>
-        </ul>
-        ''')
-
-    try:
-        browser.all('li').should(have.texts('one.', 'two.', 'three.').ignoring_case)
-
-        pytest.fail('should have failed on collection texts mismatch')
-
-    except TimeoutException as error:
-        message = str(error)
-
-        assert (
-            "browser.all(('css selector', 'li')).have texts ignoring case: "
-            "['one.', 'two.', 'three.']"
-        ) in message
-        assert (
-            "browser.all(('css selector', 'li')).have texts "
-            "['one.', 'two.', 'three.']"
-        ) not in message

--- a/tests/integration/collection__should__keeps_condition_name_test.py
+++ b/tests/integration/collection__should__keeps_condition_name_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from selene import have
+from selene.core.exceptions import TimeoutException
+from tests.integration.helpers.givenpage import GivenPage
+
+
+def test_collection_should_keeps_entity_aware_condition_name(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <ul>
+            <li>One</li>
+            <li>Two</li>
+            <li>Three</li>
+        </ul>
+        ''')
+
+    try:
+        browser.all('li').should(have.size(2))
+
+        pytest.fail('should have failed on collection size mismatch')
+
+    except TimeoutException as error:
+        message = str(error)
+
+        assert "browser.all(('css selector', 'li')).have size 2" in message
+        assert "browser.all(('css selector', 'li')).has size 2" not in message
+
+
+def test_collection_should_keeps_ignore_case_condition_name(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <ul>
+            <li>1) One!!!</li>
+            <li>2) Two...</li>
+            <li>3) Three???</li>
+        </ul>
+        ''')
+
+    try:
+        browser.all('li').should(have.texts('one.', 'two.', 'three.').ignoring_case)
+
+        pytest.fail('should have failed on collection texts mismatch')
+
+    except TimeoutException as error:
+        message = str(error)
+
+        assert (
+            "browser.all(('css selector', 'li')).have texts ignoring case: "
+            "['one.', 'two.', 'three.']"
+        ) in message
+        assert (
+            "browser.all(('css selector', 'li')).have texts "
+            "['one.', 'two.', 'three.']"
+        ) not in message


### PR DESCRIPTION
## Summary

Fixes `collection.should(...)` when a composed element condition is passed directly to a collection.

Previously, conditions like:

```python
browser.all('.item').should(
    have.css_class('disabled')
    .and_(have.attribute('aria-disabled').value('true'))
)
````

or:

```python
browser.all('.cell').should(
    have.text('Bob Flemming')
    .or_(have.text('Flemming Bob'))
)
```

could fail with low-level errors such as:

```text
'list' object has no attribute 'get_attribute'
'list' object has no attribute 'text'
```

because the composed element condition was applied to the located collection list instead of collection items.

## Changes

* Add backward-compatible handling in `Collection.should(...)`.
* Keep collection conditions applied to the collection itself.
* Fallback to `Condition.for_each(...)` only for the known case where an element condition is applied to a raw located list.
* Add regression tests for composed `.and_` and `.or_` element conditions.

## Tests

Added coverage for:

* `collection.should(have.text(...).or_(...))`
* `collection.should(have.css_class(...).and_(have.attribute(...)))`
* per-item mismatch reporting
* preserving normal collection condition behavior

Fixes #433.
