### PR TITLE
Fix coverage summary columns in GitHub step summary backport

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,21 +131,31 @@ jobs:
             echo "## Coverage summary"
             echo ""
             echo "### Full selene (line + branch)"
+            echo '```text'
             poetry run coverage report --data-file=.coverage --skip-covered
+            echo '```'
             echo ""
             echo "### selene/core slice"
+            echo '```text'
             poetry run coverage report --data-file=.coverage --include="*/selene/core/*"
+            echo '```'
             echo ""
             echo "### Test layers"
             echo ""
             echo "#### unit"
+            echo '```text'
             poetry run coverage report --data-file=.coverage.unit --skip-covered
+            echo '```'
             echo ""
             echo "#### integration"
+            echo '```text'
             poetry run coverage report --data-file=.coverage.integration --skip-covered
+            echo '```'
             echo ""
             echo "#### acceptance"
+            echo '```text'
             poetry run coverage report --data-file=.coverage.acceptance --skip-covered
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Code Coverage (selene)


### PR DESCRIPTION
## Problem: no columns in coverage report Summary

<img width="1302" height="950" alt="Снимок экрана 2026-05-13 в 13 58 54" src="https://github.com/user-attachments/assets/0b488614-e777-4762-8844-b51702c029af" />
