### PR TITLE
Fix #211: use DOM attribute value for href/src in have.attribute(...) backport

### DIFF
--- a/selene/core/match.py
+++ b/selene/core/match.py
@@ -182,9 +182,22 @@ def element_has_css_property(name: str):
 
 def element_has_attribute(name: str):
     def attribute_value(element: Element):
+        if name in ('href', 'src'):
+            return element.config.driver.execute_script(
+                'return arguments[0].getAttribute(arguments[1])', element(), name
+            )
+
         return element().get_attribute(name)
 
     def attribute_values(collection: Collection):
+        if name in ('href', 'src'):
+            return [
+                collection.config.driver.execute_script(
+                    'return arguments[0].getAttribute(arguments[1])', element, name
+                )
+                for element in collection()
+            ]
+
         return [element.get_attribute(name) for element in collection()]
 
     raw_attribute_condition = ElementCondition.raise_if_not_actual(

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -61,7 +61,9 @@ def test_have_attribute_href_value_uses_dom_attribute_not_absolute_url(session_b
     browser.element('.nav').should(have.attribute('href').value('#second'))
 
 
-def test_have_attribute_href_values_uses_dom_attribute_not_absolute_urls(session_browser):
+def test_have_attribute_href_values_uses_dom_attribute_not_absolute_urls(
+    session_browser,
+):
     browser = session_browser.with_(timeout=0.1)
 
     GivenPage(browser.driver).opened_with_body('''

--- a/tests/integration/condition__elements__have_attribute_and_co_test.py
+++ b/tests/integration/condition__elements__have_attribute_and_co_test.py
@@ -49,3 +49,44 @@ def test_have_no_attribute_descriptor_methods_work(session_browser):
 
     with pytest.raises(AssertionError):
         names.should(have.no.attribute('id').values_containing('first', 'last'))
+
+
+def test_have_attribute_href_value_uses_dom_attribute_not_absolute_url(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <a class="nav" href="#second">go to Heading 2</a>
+    ''')
+
+    browser.element('.nav').should(have.attribute('href').value('#second'))
+
+
+def test_have_attribute_href_values_uses_dom_attribute_not_absolute_urls(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <a class="nav" href="#first">go to Heading 1</a>
+        <a class="nav" href="#second">go to Heading 2</a>
+    ''')
+
+    browser.all('.nav').should(have.attribute('href').values('#first', '#second'))
+
+
+def test_have_attribute_src_value_uses_dom_attribute_not_absolute_url(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <img class="logo" src="images/logo.png" />
+    ''')
+
+    browser.element('.logo').should(have.attribute('src').value('images/logo.png'))
+
+
+def test_have_attribute_id_value_keeps_default_get_attribute_behavior(session_browser):
+    browser = session_browser.with_(timeout=0.1)
+
+    GivenPage(browser.driver).opened_with_body('''
+        <input class="name" id="firstname" value="John">
+    ''')
+
+    browser.element('.name').should(have.attribute('id').value('firstname'))


### PR DESCRIPTION
## What
Fixes issue #211 where `have.attribute('href').value(...)` failed because Selenium WebDriver returns an absolute URL for `href`/`src` via `get_attribute`.

## Changes
- Updated `element_has_attribute` in `selene/core/match.py`:
  - for `href` and `src`, value is now read via JS DOM API:
    - `arguments[0].getAttribute(arguments[1])`
  - applied to both:
    - single element checks (`value`, `value_containing`)
    - collection checks (`values`, `values_containing`)
- Kept default `get_attribute` behavior for all other attributes.

## Tests
Added integration regressions in:
`tests/integration/condition__elements__have_attribute_and_co_test.py`

New coverage:
- `href` on single element (`value`)
- `href` on collection (`values`)
- `src` on single element (`value`)
- sanity check for non-special attribute (`id`) to confirm unchanged behavior

## Validation
- New regression reproduces the original failure before patch.
- After patch:
  - target test passes
  - full file passes (`6 passed`)

## Why
Selene condition API should reflect user-visible DOM attribute semantics (`#/active`, relative `src`) rather than webdriver-normalized absolute URLs for these attributes.
