### PR TITLE
CHORE ci: split acceptance tests and trim coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        experimental:
+          - false
+        include:
+          - python-version: "3.15.0-beta.1"
+            experimental: true
 
     env:
       DISPLAY: ":99"
@@ -71,22 +76,13 @@ jobs:
           poetry run pytest -sv \
             --cov-config .coveragerc \
             --cov-branch \
-            --cov-report html:skip-covered \
-            --cov-report term:skip-covered \
             --cov=selene \
             --cov-report xml:coverage.xml \
             --tb=short \
             -m "not (clipboard or speed or remote or flaky)" \
+            --ignore=tests/acceptance \
             tests/ \
             --headless=True
-
-      - name: Build package-slice coverage reports
-        if: matrix.python-version == '3.10' && always()
-        run: |
-          poetry run coverage xml -i --include="*/selene/core/*" -o coverage-core.xml
-          poetry run coverage xml -i --include="*/selene/common/*" -o coverage-common.xml
-          poetry run coverage xml -i --include="*/selene/support/*" -o coverage-support.xml
-          poetry run coverage xml -i --include="*/selene/api/*" -o coverage-api.xml
 
       - name: Unit tests coverage report
         if: matrix.python-version == '3.10' && always()
@@ -101,34 +97,6 @@ jobs:
             tests/unit \
             --headless=True
           COVERAGE_FILE=.coverage.unit poetry run coverage xml -i -o coverage-unit.xml
-
-      - name: Integration tests coverage report
-        if: matrix.python-version == '3.10' && always()
-        run: |
-          COVERAGE_FILE=.coverage.integration poetry run pytest -sv \
-            --cov-config .coveragerc \
-            --cov-branch \
-            --cov=selene \
-            --cov-report= \
-            --tb=short \
-            -m "not (clipboard or speed or remote or flaky)" \
-            tests/integration \
-            --headless=True
-          COVERAGE_FILE=.coverage.integration poetry run coverage xml -i -o coverage-integration.xml
-
-      - name: Acceptance tests coverage report
-        if: matrix.python-version == '3.10' && always()
-        run: |
-          COVERAGE_FILE=.coverage.acceptance poetry run pytest -sv \
-            --cov-config .coveragerc \
-            --cov-branch \
-            --cov=selene \
-            --cov-report= \
-            --tb=short \
-            -m "not (clipboard or speed or remote or flaky)" \
-            tests/acceptance \
-            --headless=True
-          COVERAGE_FILE=.coverage.acceptance poetry run coverage xml -i -o coverage-acceptance.xml
 
       - name: Debug coverage artifacts
         if: matrix.python-version == '3.10' && always()
@@ -147,26 +115,11 @@ jobs:
             poetry run coverage report --data-file=.coverage --skip-covered
             echo '```'
             echo ""
-            echo "### selene/core slice"
-            echo '```text'
-            poetry run coverage report --data-file=.coverage --include="*/selene/core/*"
-            echo '```'
-            echo ""
             echo "### Test layers"
             echo ""
             echo "#### unit"
             echo '```text'
             poetry run coverage report --data-file=.coverage.unit --skip-covered
-            echo '```'
-            echo ""
-            echo "#### integration"
-            echo '```text'
-            poetry run coverage report --data-file=.coverage.integration --skip-covered
-            echo '```'
-            echo ""
-            echo "#### acceptance"
-            echo '```text'
-            poetry run coverage report --data-file=.coverage.acceptance --skip-covered
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -183,58 +136,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Code Coverage (core)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-core.xml
-          disable_search: true
-          flags: core
-          name: core-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Code Coverage (common)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-common.xml
-          disable_search: true
-          flags: common
-          name: common-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Code Coverage (support)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-support.xml
-          disable_search: true
-          flags: support
-          name: support-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Code Coverage (api)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-api.xml
-          disable_search: true
-          flags: api
-          name: api-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Code Coverage (unit)
         if: matrix.python-version == '3.10' && always()
         uses: codecov/codecov-action@v5
@@ -243,32 +144,6 @@ jobs:
           disable_search: true
           flags: unit
           name: unit-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Code Coverage (integration)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-integration.xml
-          disable_search: true
-          flags: integration
-          name: integration-py310
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Code Coverage (acceptance)
-        if: matrix.python-version == '3.10' && always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage-acceptance.xml
-          disable_search: true
-          flags: acceptance
-          name: acceptance-py310
           fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           verbose: true
         env:
@@ -322,6 +197,30 @@ jobs:
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
       - name: Speed tests
         run: poetry run pytest -sv --tb=short -m "speed" tests/ --headless=True
+
+  acceptance:
+    name: Acceptance (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      DISPLAY: ":99"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Install xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+      - name: Acceptance tests
+        run: poetry run pytest -sv --tb=short -m "not speed" tests/acceptance --headless=True
 
   remote:
     name: Remote (non-blocking)

--- a/tests/acceptance/custom_driver_via_fixtures/test_ecosia.py
+++ b/tests/acceptance/custom_driver_via_fixtures/test_ecosia.py
@@ -19,7 +19,13 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import pytest
+
 from selene import by, have
+
+pytestmark = pytest.mark.skip(
+    reason='Ecosia currently blocks automated traffic with Cloudflare captcha'
+)
 
 
 def _hide_cookie_overlays(browser):


### PR DESCRIPTION
## What changed
- Moved `tests/acceptance` into a separate non-blocking GitHub Actions job.
- Excluded `tests/acceptance` from the blocking regression run.
- Simplified the coverage setup in `tests.yml` by removing extra slice reports.
- Marked the Ecosia scenario as `skip` because the site now blocks automation with a Cloudflare captcha.
- Added `3.15.0-beta.1` to the regression matrix as an experimental run.

## Why
- To keep regression independent from flaky or externally controlled acceptance scenarios.
- To make CI faster and easier to maintain.
- To avoid spending CI time on a test that is currently blocked by Ecosia anti-bot protection.

## Notes
- The separate `acceptance` job remains non-blocking.
- The `speed` job stays separate as before.