### PR TITLE
FIX: #446 Deprecate browser.execute_script shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -839,7 +839,7 @@ browser.element('[id^=google_ads]').execute_script('element.remove()')
 # OR
 browser.element('[id^=google_ads]').execute_script('self.remove()')
 '''
-# are shortcuts to
+# are roughly equivalent to the lower-level Selenium call:
 browser.driver.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
 '''
 
@@ -847,7 +847,7 @@ browser.element('input').execute_script('element.value=arguments[0]', 'new value
 # OR
 browser.element('input').execute_script('self.value=arguments[0]', 'new value')
 '''
-# are shortcuts to
+# are roughly equivalent to the lower-level Selenium call:
 browser.driver.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
 '''
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -840,7 +840,7 @@ browser.element('[id^=google_ads]').execute_script('element.remove()')
 browser.element('[id^=google_ads]').execute_script('self.remove()')
 '''
 # are shortcuts to
-browser.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
+browser.driver.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
 '''
 
 browser.element('input').execute_script('element.value=arguments[0]', 'new value')
@@ -848,7 +848,7 @@ browser.element('input').execute_script('element.value=arguments[0]', 'new value
 browser.element('input').execute_script('self.value=arguments[0]', 'new value')
 '''
 # are shortcuts to
-browser.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
+browser.driver.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
 '''
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -839,7 +839,7 @@ browser.element('[id^=google_ads]').execute_script('element.remove()')
 # OR
 browser.element('[id^=google_ads]').execute_script('self.remove()')
 '''
-# are roughly equivalent to the lower-level Selenium call:
+# Both forms are element-scoped convenience alternatives to the lower-level Selenium call:
 browser.driver.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
 '''
 
@@ -847,7 +847,7 @@ browser.element('input').execute_script('element.value=arguments[0]', 'new value
 # OR
 browser.element('input').execute_script('self.value=arguments[0]', 'new value')
 '''
-# are roughly equivalent to the lower-level Selenium call:
+# Both forms are element-scoped convenience alternatives to the lower-level Selenium call:
 browser.driver.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
 '''
 ```

--- a/selene/core/_browser.py
+++ b/selene/core/_browser.py
@@ -176,7 +176,7 @@ class Browser(WaitingEntity['Browser']):
         warnings.warn(
             'consider using browser.driver.execute_script '
             'instead of browser.execute_script',
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         return self.driver.execute_script(script, *args)
 

--- a/selene/core/entity.py
+++ b/selene/core/entity.py
@@ -270,7 +270,7 @@ class Element(WaitingEntity['Element']):
             # OR
             browser.element('[id^=google_ads]').execute_script('self.remove()')
             '''
-            # are shortcuts to
+            # Both forms are element-scoped convenience alternatives to the lower-level Selenium call:
             browser.driver.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
             '''
 
@@ -278,7 +278,7 @@ class Element(WaitingEntity['Element']):
             # OR
             browser.element('input').execute_script('self.value=arguments[0]', 'new value')
             '''
-            # are shortcuts to
+            # Both forms are element-scoped convenience alternatives to the lower-level Selenium call:
             browser.driver.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
             '''
         """

--- a/selene/core/entity.py
+++ b/selene/core/entity.py
@@ -271,7 +271,7 @@ class Element(WaitingEntity['Element']):
             browser.element('[id^=google_ads]').execute_script('self.remove()')
             '''
             # are shortcuts to
-            browser.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
+            browser.driver.execute_script('arguments[0].remove()', browser.element('[id^=google_ads]')())
             '''
 
             browser.element('input').execute_script('element.value=arguments[0]', 'new value')
@@ -279,7 +279,7 @@ class Element(WaitingEntity['Element']):
             browser.element('input').execute_script('self.value=arguments[0]', 'new value')
             '''
             # are shortcuts to
-            browser.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
+            browser.driver.execute_script('arguments[0].value=arguments[1]', browser.element('input').locate(), 'new value')
             '''
         """
         driver: WebDriver = self.config.driver

--- a/tests/unit/core/test_browser.py
+++ b/tests/unit/core/test_browser.py
@@ -180,7 +180,7 @@ def test_execute_script_and_last_properties_are_deprecated():
     config = DummyConfig()
     browser = browser_module.Browser(config)
 
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         assert browser.execute_script('return 1', 2) == 'script-result'
 
     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
### Summary

Deprecates the `browser.execute_script(...)` shortcut in favor of explicit Selenium API usage via `browser.driver.execute_script(...)`.

### Changes

* replaces `PendingDeprecationWarning` with `DeprecationWarning` for `browser.execute_script(...)`;
* keeps the shortcut as a temporary compatibility shim;
* updates examples to use `browser.driver.execute_script(...)`.

### Motivation

This aligns the 2.0 API cleanup with #446: Selene should not keep a browser-level shortcut for raw Selenium script execution when the same operation is already available explicitly through `browser.driver`.

Deprecated compatibility APIs are expected to be removed before the final `2.0.0` release.
