### PR TITLE
Fix typing of Condition.each/for_each to return Condition[Collection] (#541)

### DIFF
--- a/selene/core/condition.py
+++ b/selene/core/condition.py
@@ -429,6 +429,7 @@ and its [`Match`][selene.core.condition.Match] subclass, allowing to build such
 
 ## ⬇️ Classes to build and recompose conditions
 """
+
 from __future__ import annotations
 
 import functools
@@ -460,6 +461,9 @@ if sys.version_info >= (3, 10):
     from collections.abc import Callable
 else:
     from typing import Callable
+
+if typing.TYPE_CHECKING:
+    from selene.core.entity import Collection
 
 
 # TODO: Consider renaming to Match, while keeping Condition name as functional interface
@@ -950,7 +954,7 @@ class Condition(Generic[E]):
         return cls(' or '.join(map(str, conditions)), func)
 
     @classmethod
-    def for_each(cls, condition) -> Condition[Iterable[E]]:
+    def for_each(cls, condition) -> Condition[Collection]:
         # TODO: consider refactoring to be predicate-based or both-based
         #      and ensure inverted works
         def func(entity):
@@ -969,7 +973,7 @@ class Condition(Generic[E]):
                     )
                 )
 
-        return typing.cast(Condition[Iterable[E]], cls(f' each {condition}', func))
+        return typing.cast('Condition[Collection]', cls(f' each {condition}', func))
 
     @classmethod
     def as_not(
@@ -1336,7 +1340,7 @@ class Condition(Generic[E]):
         return Condition.by_or(self, condition)
 
     @property
-    def each(self) -> Condition[Iterable[E]]:
+    def each(self) -> Condition[Collection]:
         return Condition.for_each(self)
 
 


### PR DESCRIPTION
Fixes #541.

## Problem

`Condition.each` and `Condition.for_each` were typed to return
`Condition[Iterable[E]]`. Because `Condition` is invariant in its generic
parameter, PyCharm's type checker couldn't resolve
`Condition[Iterable[Element]]` against the `Condition[Collection]` bound
expected by a collection entity's `.should()` — even though `Collection`
is itself an `Iterable[Element]` at runtime. This produced a false-positive
type mismatch warning in PyCharm for code like:

    ss('').should(have.text('').each)

## Fix

Changed both return type annotations (`for_each` and the `each` property)
from `Condition[Iterable[E]]` to `Condition[Collection]`, matching what
`.should()` actually expects on collection entities. `Collection` is
imported under `TYPE_CHECKING` to avoid a circular import with
`entity.py`.

## Verification

- `mypy selene/core/condition.py` — no issues
- Confirmed via `reveal_type()` that `Condition[Element].each` now
  resolves to `Condition[Collection]` (previously
  `Condition[Iterable[Element]]`)
- `pytest tests/unit` — all 62 tests pass
- `black --check` — clean

I don't have PyCharm available to visually confirm the IDE warning
disappears, but the mypy `reveal_type` output confirms the underlying
type resolution now matches what `.should()` expects. Would appreciate
a maintainer with PyCharm doing a final visual check on
`ss('').should(have.text('').each)`.