### PR TITLE
feat: implement pluggable retry strategies for waiting (#584)

### DIFF
--- a/selene/core/configuration.py
+++ b/selene/core/configuration.py
@@ -56,6 +56,7 @@ from selene.common.helpers import on_error_return_false
 from selene.core.exceptions import TimeoutException
 
 from selene.core.wait import Wait
+from selene.core.retry import RetryStrategy, FixedDelay
 
 E = TypeVar('E')
 
@@ -1051,6 +1052,9 @@ class Config:
     poll_during_waits: int = 100
     """A fake option, not currently used in Selene waiting:)"""
 
+    retry_strategy: Optional[RetryStrategy] = None
+    """Pluggable strategy with custom backoff algorithm for waiting"""
+
     # --- Web-specific options ---
     # TODO: should we pass here None?
     #       and use "not None" as _get_base_url_on_open_with_no_args=True?
@@ -1665,10 +1669,11 @@ class Config:
                 # )
             ),
             _decorator=config._wait_decorator,
+            retry_strategy=config.retry_strategy,
         )
     )
     """A strategy for building a Wait object based on other config options
-    like `config.timeout`, `config.hook_wait_failure`, `config._wait_decorator`, etc.
+    like `config.timeout`, `config.hook_wait_failure`, `config._wait_decorator`, `config.retry_strategy`, etc.
     """
 
     # TODO: we definitely not need it inside something called Config,

--- a/selene/core/retry.py
+++ b/selene/core/retry.py
@@ -1,0 +1,64 @@
+import random
+from abc import ABC, abstractmethod
+from typing import Iterator
+
+class RetryStrategy(ABC):
+    @abstractmethod
+    def __iter__(self) -> Iterator[float]:
+        pass
+
+class FixedDelay(RetryStrategy):
+    def __init__(self, delay: float = 0.1):
+        self.delay = delay
+        
+    def __iter__(self) -> Iterator[float]:
+        while True:
+            yield self.delay
+
+class ExponentialBackoff(RetryStrategy):
+    def __init__(self, initial_delay: float = 0.1, multiplier: float = 2.0, max_delay: float = 5.0):
+        self.initial_delay = initial_delay
+        self.multiplier = multiplier
+        self.max_delay = max_delay
+        
+    def __iter__(self) -> Iterator[float]:
+        delay = self.initial_delay
+        while True:
+            yield delay
+            delay = min(delay * self.multiplier, self.max_delay)
+
+class LinearBackoff(RetryStrategy):
+    def __init__(self, initial_delay: float = 0.1, step: float = 0.1, max_delay: float = 5.0):
+        self.initial_delay = initial_delay
+        self.step = step
+        self.max_delay = max_delay
+        
+    def __iter__(self) -> Iterator[float]:
+        delay = self.initial_delay
+        while True:
+            yield delay
+            delay = min(delay + self.step, self.max_delay)
+
+class FibonacciBackoff(RetryStrategy):
+    def __init__(self, initial_delay: float = 0.1, max_delay: float = 5.0):
+        self.initial_delay = initial_delay
+        self.max_delay = max_delay
+        
+    def __iter__(self) -> Iterator[float]:
+        a, b = 1, 1
+        while True:
+            delay = min(self.initial_delay * a, self.max_delay)
+            yield delay
+            a, b = b, a + b
+
+class JitteredBackoff(RetryStrategy):
+    def __init__(self, initial_delay: float = 0.1, max_delay: float = 5.0, factor: float = 2.0):
+        self.initial_delay = initial_delay
+        self.max_delay = max_delay
+        self.factor = factor
+        
+    def __iter__(self) -> Iterator[float]:
+        delay = self.initial_delay
+        while True:
+            yield random.uniform(0, delay)
+            delay = min(delay * self.factor, self.max_delay)

--- a/selene/core/wait.py
+++ b/selene/core/wait.py
@@ -30,6 +30,7 @@ from selene.core.exceptions import TimeoutException
 
 from selene.common.fp import identity
 from selene.common._typing_functions import Query, Command
+from selene.core.retry import RetryStrategy, FixedDelay
 
 T = TypeVar('T')
 R = TypeVar('R')
@@ -50,6 +51,7 @@ class Wait(Generic[E]):
         _decorator: (
             Callable[[Wait[E]], Callable[[Callable[..., R]], Callable[..., R]]] | None
         ) = None,
+        retry_strategy: Optional[RetryStrategy] = None,
         # TODO: should not we add here ignore_exceptions?
         #       (called as _falsy_exceptions in Condition init)
         #       and then tune it depending on context,
@@ -61,16 +63,24 @@ class Wait(Generic[E]):
         self._timeout = at_most
         self._hook_failure = or_fail_with or identity
         self._decorator = _decorator or (lambda wait: identity)
+        self._retry_strategy = retry_strategy or FixedDelay(0.1)
 
     def with_(
         self,
         *,
         decorator: (
             Callable[[Wait[E]], Callable[[Callable[..., R]], Callable[..., R]]] | None
-        ),
+        ) = None,
+        retry_strategy: Optional[RetryStrategy] = None,
         # TODO: consider adding other options for consistency
     ) -> Wait[E]:
-        return Wait(self.entity, self._timeout, self._hook_failure, decorator)
+        return Wait(
+            self.entity,
+            self._timeout,
+            self._hook_failure,
+            decorator if decorator is not None else self._decorator,
+            retry_strategy if retry_strategy is not None else self._retry_strategy,
+        )
 
     @property
     def _entity(self):
@@ -82,12 +92,12 @@ class Wait(Generic[E]):
         return self.entity
 
     def at_most(self, timeout: float) -> Wait[E]:
-        return Wait(self.entity, timeout, self._hook_failure)
+        return Wait(self.entity, timeout, self._hook_failure, self._decorator, self._retry_strategy)
 
     def or_fail_with(
         self, hook_failure: Optional[Callable[[TimeoutException], Exception]]
     ) -> Wait[E]:
-        return Wait(self.entity, self._timeout, hook_failure)
+        return Wait(self.entity, self._timeout, hook_failure, self._decorator, self._retry_strategy)
 
     @property
     def hook_failure(
@@ -101,6 +111,7 @@ class Wait(Generic[E]):
     def for_(self, fn: Callable[[E], R]) -> R:
         def logic(fn: Callable[[E], R]) -> R:
             finish_time = time.time() + self._timeout
+            delays = iter(self._retry_strategy)
 
             while True:
                 try:
@@ -135,6 +146,7 @@ class Wait(Generic[E]):
                         )
 
                         raise self._hook_failure(failure)
+                    time.sleep(next(delays))
 
         decorator = cast(
             Callable[[Wait[E]], Callable[[Callable[..., R]], Callable[..., R]]],
@@ -150,6 +162,7 @@ class Wait(Generic[E]):
                 self._timeout,
                 or_fail_with=identity,
                 _decorator=self._decorator,
+                retry_strategy=self._retry_strategy,
             ).for_(fn)
             return True
         except TimeoutException:


### PR DESCRIPTION
Fixes #584. Extends Selene's implicit wait and retry mechanism to support pluggable retry strategies with custom backoff algorithms.